### PR TITLE
Fixed deprecation of Redis.current

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,8 @@ Rails/UnknownEnv:
 
 Rails/EnvironmentVariableAccess:
   AllowReads: true
+
+Lint/MissingSuper:
+  Enabled: true
+  Exclude:
+    - lib/redis_pool.rb

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development do
 end
 
 gem 'apple_music'
+gem 'connection_pool'
 gem 'faraday'
 gem 'meilisearch-rails'
 gem 'pagy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crass (1.0.6)
     digest (3.1.0)
     domain_name (0.5.20190701)
@@ -310,6 +311,7 @@ DEPENDENCIES
   apple_music
   bootsnap (>= 1.4.4)
   byebug
+  connection_pool
   dotenv-rails
   faraday
   listen (~> 3.7)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,13 +3,17 @@
 class SessionsController < ApplicationController
   def create
     user = User.find_or_create_from_auth_hash(auth_hash)
-    Redis.current.set(user.id, auth_hash.to_json)
+    RedisPool.with do |redis|
+      redis.set(user.id, auth_hash.to_json)
+    end
+
     session[:user_id] = user.id
     redirect_to root_path
   end
 
   def destroy
-    Redis.current.del(session[:user_id])
+    redis = RedisPool.get
+    redis.del(session[:user_id])
     reset_session
     redirect_to root_path
   end

--- a/app/controllers/spotify/playlists_controller.rb
+++ b/app/controllers/spotify/playlists_controller.rb
@@ -7,7 +7,8 @@ module Spotify
     def create
       redirect_to root_url unless session[:user_id]
 
-      auth_hash = JSON.parse(Redis.current.get(session[:user_id]))
+      redis = RedisPool.get
+      auth_hash = JSON.parse(redis.get(session[:user_id]))
       @spotify_user = RSpotify::User.new(auth_hash)
 
       offset = 0

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,8 @@ require 'rails/test_unit/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative '../lib/redis_pool'
+
 module TouhouMusicDiscover
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require 'redis'
-
-Redis.current = Redis.new(url: ENV['REDIS_URL'])

--- a/lib/redis_pool.rb
+++ b/lib/redis_pool.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'connection_pool'
+
+class RedisPool
+  class Wrapper < ConnectionPool::Wrapper
+    def initialize(pool)
+      @pool = pool
+    end
+  end
+
+  class << self
+    # Redis へのコネクションを取得する
+    def with(&)
+      pool.with(&)
+    end
+
+    # Redis へのコネクションを取得する (redis.gem との互換性維持用)
+    def get
+      Wrapper.new(pool)
+    end
+
+    private
+
+    def pool
+      @pool ||= ConnectionPool.new(
+        size: ENV.fetch('RAILS_MAX_THREADS', 2).to_i,
+        timeout: ENV.fetch('REDIS_TIMEOUT', 1).to_i
+      ) { Redis.new(url: ENV['REDIS_URL']) }
+    end
+  end
+end


### PR DESCRIPTION
# 概要

`Redis.current`がredis 4.6.0から非推奨になり、redis 5.0で削除される。
- https://github.com/redis/redis-rb/blob/v4.6.0/CHANGELOG.md#460

## 対応内容

- `Redis.current`を使用しないように修正