### PR TITLE
apple_music gemの依存を削除し、独自実装に移行

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,3 +51,8 @@ Style/SignalException:
   Enabled: true
   Exclude:
     - app/avo/actions/*.rb
+
+Style/OpenStructUse:
+  Enabled: true
+  Exclude:
+    - lib/apple_music/response.rb

--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,11 @@ group :development do
 end
 
 gem 'amatch'
-gem 'apple_music'
 gem 'avo'
 gem 'connection_pool'
 gem 'csv'
-gem 'faraday'
-gem 'faraday_middleware'
+gem 'faraday', '~> 2.0'
+gem 'jwt'
 gem 'meilisearch-rails'
 gem 'pagy'
 gem 'parallel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,10 +80,6 @@ GEM
     amatch (0.4.1)
       mize
       tins (~> 1.0)
-    apple_music (0.3.1)
-      faraday
-      faraday_middleware
-      jwt (>= 2.2)
     ast (2.4.3)
     avo (2.53.0)
       actionview (>= 6.0)
@@ -125,31 +121,12 @@ GEM
     dry-initializer (3.1.1)
     erb (5.0.1)
     erubi (1.13.1)
-    faraday (1.10.4)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.2)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_middleware (1.2.1)
-      faraday (~> 1.0)
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -208,8 +185,9 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
-    multipart-post (2.3.0)
     mutex_m (0.3.0)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.8)
       date
       net-protocol
@@ -379,7 +357,6 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     ruby_parser (3.19.1)
       sexp_processor (~> 4.16)
     securerandom (0.4.1)
@@ -404,6 +381,7 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.6.0)
+    uri (1.0.3)
     useragent (0.16.11)
     view_component (3.20.0)
       activesupport (>= 5.2.0, < 8.1)
@@ -426,7 +404,6 @@ PLATFORMS
 
 DEPENDENCIES
   amatch
-  apple_music
   avo
   bootsnap (>= 1.4.4)
   byebug
@@ -434,9 +411,9 @@ DEPENDENCIES
   cssbundling-rails
   csv
   dotenv-rails
-  faraday
-  faraday_middleware
+  faraday (~> 2.0)
   jsbundling-rails
+  jwt
   listen (~> 3.8)
   meilisearch-rails
   omniauth-rails_csrf_protection

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ require_relative '../lib/redis_pool'
 require_relative '../lib/line_music'
 require_relative '../lib/ytmusic'
 require_relative '../lib/similar'
+require_relative '../lib/apple_music'
 
 module TouhouMusicDiscover
   class Application < Rails::Application

--- a/lib/apple_music.rb
+++ b/lib/apple_music.rb
@@ -20,5 +20,4 @@ module AppleMusic
       yield(config)
     end
   end
-
 end

--- a/lib/apple_music.rb
+++ b/lib/apple_music.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'date'
+require_relative 'apple_music/config'
+require_relative 'apple_music/connection'
+require_relative 'apple_music/response'
+require_relative 'apple_music/album'
+require_relative 'apple_music/artist'
+require_relative 'apple_music/song'
+
+module AppleMusic
+  class << self
+    attr_writer :config
+
+    def config
+      @config ||= Config.new
+    end
+
+    def configure
+      yield(config)
+    end
+  end
+
+end

--- a/lib/apple_music/album.rb
+++ b/lib/apple_music/album.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module AppleMusic
+  class Album
+    class << self
+      def find(id, storefront: AppleMusic.config.storefront)
+        path = build_path(storefront, id)
+        response = connection.get(path)
+        Response.new(response).first
+      end
+
+      def list(ids: [], upc: '', storefront: AppleMusic.config.storefront)
+        return get_collection_by_ids(ids, storefront: storefront) if ids.present?
+        return get_collection_by_upc(upc, storefront: storefront) if upc.present?
+
+        raise ParameterMissing, 'Either ids or upc must be provided'
+      end
+
+      def get_collection_by_ids(ids, storefront: AppleMusic.config.storefront)
+        ids_string = ids.is_a?(Array) ? ids.join(',') : ids
+        path = build_path(storefront)
+        params = { ids: ids_string }
+
+        response = connection.get(path, params)
+        Response.new(response).items
+      end
+
+      def get_collection_by_upc(upc, storefront: AppleMusic.config.storefront)
+        path = build_path(storefront)
+        params = { 'filter[upc]' => upc }
+
+        response = connection.get(path, params)
+        Response.new(response).items
+      end
+
+      def get_relationship(id, relationship_type, limit: nil, offset: nil, storefront: AppleMusic.config.storefront)
+        path = build_path(storefront, id, relationship_type)
+        params = {}
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+
+        response = connection.get(path, params)
+        Response.new(response).items
+      end
+
+      def search(term, limit: nil, offset: nil, storefront: AppleMusic.config.storefront)
+        path = "catalog/#{storefront}/search"
+        params = {
+          term: term,
+          types: 'albums'
+        }
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+
+        response = connection.get(path, params)
+        Response.new(response).results
+      end
+
+      private
+
+      def connection
+        @connection ||= Connection.new(AppleMusic.config)
+      end
+
+      def build_path(storefront, *segments)
+        path_parts = ['catalog', storefront, 'albums', *segments].compact
+        path_parts.join('/')
+      end
+    end
+  end
+end

--- a/lib/apple_music/artist.rb
+++ b/lib/apple_music/artist.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module AppleMusic
+  class Artist
+    class << self
+      def find(id, storefront: AppleMusic.config.storefront)
+        path = build_path(storefront, id)
+        response = connection.get(path)
+        Response.new(response).first
+      end
+
+      def list(ids:, storefront: AppleMusic.config.storefront)
+        get_collection_by_ids(ids, storefront: storefront)
+      end
+
+      def get_collection_by_ids(ids, storefront: AppleMusic.config.storefront)
+        ids_string = ids.is_a?(Array) ? ids.join(',') : ids
+        path = build_path(storefront)
+        params = { ids: ids_string }
+
+        response = connection.get(path, params)
+        Response.new(response).items
+      end
+
+      def get_relationship(id, relationship_type, limit: nil, offset: nil, storefront: AppleMusic.config.storefront)
+        path = build_path(storefront, id, relationship_type)
+        params = {}
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+
+        response = connection.get(path, params)
+        Response.new(response).items
+      end
+
+      def search(term, limit: nil, offset: nil, storefront: AppleMusic.config.storefront)
+        path = "catalog/#{storefront}/search"
+        params = {
+          term: term,
+          types: 'artists'
+        }
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+
+        response = connection.get(path, params)
+        Response.new(response).results
+      end
+
+      private
+
+      def connection
+        @connection ||= Connection.new(AppleMusic.config)
+      end
+
+      def build_path(storefront, *segments)
+        path_parts = ['catalog', storefront, 'artists', *segments].compact
+        path_parts.join('/')
+      end
+    end
+  end
+end

--- a/lib/apple_music/config.rb
+++ b/lib/apple_music/config.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'jwt'
+
+module AppleMusic
+  class Config
+    attr_accessor :secret_key_path, :secret_key, :team_id, :music_id, :storefront, :adapter
+
+    def initialize
+      @secret_key_path = ENV.fetch('APPLE_MUSIC_SECRET_KEY_PATH', nil)
+      @secret_key = ENV.fetch('APPLE_MUSIC_SECRET_KEY', nil)
+      @team_id = ENV.fetch('APPLE_MUSIC_TEAM_ID', nil)
+      @music_id = ENV.fetch('APPLE_MUSIC_MUSIC_ID', nil)
+      @storefront = ENV.fetch('APPLE_MUSIC_STOREFRONT', 'jp')
+      @adapter = :net_http
+    end
+
+    def authentication_token
+      private_key = OpenSSL::PKey::EC.new(secret_key_value)
+
+      payload = {
+        iss: team_id,
+        iat: Time.now.to_i,
+        exp: Time.now.to_i + 86_400 # 24 hours
+      }
+
+      JWT.encode(payload, private_key, 'ES256', kid: music_id)
+    end
+
+    private
+
+    def secret_key_value
+      return File.read(secret_key_path) if secret_key_path && File.exist?(secret_key_path)
+      return secret_key if secret_key
+
+      raise ParameterMissing, 'Either secret_key_path or secret_key must be provided'
+    end
+  end
+
+  class ParameterMissing < StandardError; end
+
+  class ApiError < StandardError
+    attr_reader :response
+
+    def initialize(message, response = nil)
+      super(message)
+      @response = response
+    end
+  end
+end

--- a/lib/apple_music/connection.rb
+++ b/lib/apple_music/connection.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'faraday/net_http'
+
+module AppleMusic
+  class Connection
+    API_URI = 'https://api.music.apple.com/v1/'
+
+    def initialize(config)
+      @config = config
+    end
+
+    def get(path, params = {})
+      response = connection.get(path, params)
+      handle_response(response)
+    end
+
+    def post(path, body = {})
+      response = connection.post(path, body) do |req|
+        req.headers['Content-Type'] = 'application/json'
+        req.body = body.to_json
+      end
+      handle_response(response)
+    end
+
+    private
+
+    attr_reader :config
+
+    def connection
+      @connection ||= Faraday.new(url: API_URI) do |conn|
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
+        conn.adapter config.adapter
+        conn.headers['Authorization'] = "Bearer #{config.authentication_token}"
+      end
+    end
+
+    def handle_response(response)
+      case response.status
+      when 200..299
+        response.body
+      when 401
+        raise ApiError.new('Unauthorized. Please check your authentication credentials.', response)
+      when 404
+        raise ApiError.new('Resource not found.', response)
+      when 429
+        raise ApiError.new('Rate limit exceeded. Please try again later.', response)
+      else
+        error_message = response.body.dig('errors', 0, 'detail') || "Request failed with status #{response.status}"
+        raise ApiError.new(error_message, response)
+      end
+    end
+  end
+end

--- a/lib/apple_music/response.rb
+++ b/lib/apple_music/response.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+require 'active_support/core_ext/string/inflections'
+
+module AppleMusic
+  class Response
+    attr_reader :body
+
+    def initialize(body)
+      @body = body
+    end
+
+    def data
+      body['data']
+    end
+
+    def results
+      result_data = body.dig('results', resource_type)
+      return nil unless result_data
+
+      if result_data.is_a?(Hash) && result_data['data']
+        convert_to_objects(result_data['data'])
+      else
+        convert_to_objects(result_data)
+      end
+    end
+
+    def first
+      object_data = data.is_a?(Array) ? data.first : data
+      convert_to_object(object_data)
+    end
+
+    def items
+      array_data = data || []
+      convert_to_objects(array_data)
+    end
+
+    def next_page?
+      body['next'].present?
+    end
+
+    def next_url
+      body['next']
+    end
+
+    private
+
+    def convert_to_objects(array_data)
+      return [] unless array_data.is_a?(Array)
+
+      array_data.map { |item| convert_to_object(item) }
+    end
+
+    def convert_to_object(data)
+      return nil unless data.is_a?(Hash)
+
+      object = OpenStruct.new(data['id'] ? { id: data['id'] } : {})
+
+      data['attributes']&.each do |key, value|
+        object.send("#{key.underscore}=", value)
+      end
+
+      data['relationships']&.each do |key, value|
+        object.send("#{key.underscore}=", value)
+      end
+
+      # Add as_json method to the object
+      object.define_singleton_method(:as_json) do |_options = {}|
+        data
+      end
+
+      object
+    end
+
+    def resource_type
+      # Determine resource type from response structure
+      return 'albums' if body.dig('results', 'albums')
+      return 'artists' if body.dig('results', 'artists')
+      return 'songs' if body.dig('results', 'songs')
+      return 'playlists' if body.dig('results', 'playlists')
+
+      nil
+    end
+  end
+end

--- a/lib/apple_music/song.rb
+++ b/lib/apple_music/song.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module AppleMusic
+  class Song
+    class << self
+      def find(id, storefront: AppleMusic.config.storefront)
+        path = build_path(storefront, id)
+        response = connection.get(path)
+        Response.new(response).first
+      end
+
+      def list(ids: nil, isrc: nil, storefront: AppleMusic.config.storefront)
+        return get_collection_by_ids(ids, storefront: storefront) if ids.present?
+        return get_collection_by_isrc(isrc, storefront: storefront) if isrc.present?
+
+        raise ParameterMissing, 'Either ids or isrc must be provided'
+      end
+
+      def get_collection_by_ids(ids, storefront: AppleMusic.config.storefront)
+        ids_string = ids.is_a?(Array) ? ids.join(',') : ids
+        path = build_path(storefront)
+        params = { ids: ids_string }
+
+        response = connection.get(path, params)
+        Response.new(response).items
+      end
+
+      def get_collection_by_isrc(isrc, storefront: AppleMusic.config.storefront)
+        isrc_string = isrc.is_a?(Array) ? isrc.join(',') : isrc
+        path = build_path(storefront)
+        params = { 'filter[isrc]' => isrc_string }
+
+        response = connection.get(path, params)
+        Response.new(response).items
+      end
+
+      def get_relationship(id, relationship_type, limit: nil, offset: nil, storefront: AppleMusic.config.storefront)
+        path = build_path(storefront, id, relationship_type)
+        params = {}
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+
+        response = connection.get(path, params)
+        Response.new(response).items
+      end
+
+      def search(term, limit: nil, offset: nil, storefront: AppleMusic.config.storefront)
+        path = "catalog/#{storefront}/search"
+        params = {
+          term: term,
+          types: 'songs'
+        }
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+
+        response = connection.get(path, params)
+        Response.new(response).results
+      end
+
+      private
+
+      def connection
+        @connection ||= Connection.new(AppleMusic.config)
+      end
+
+      def build_path(storefront, *segments)
+        path_parts = ['catalog', storefront, 'songs', *segments].compact
+        path_parts.join('/')
+      end
+    end
+  end
+end

--- a/lib/line_music/connection.rb
+++ b/lib/line_music/connection.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'faraday'
-require 'faraday_middleware'
 
 module LineMusic
   class ApiError < StandardError; end
@@ -15,7 +14,8 @@ module LineMusic
 
     def client
       @client ||= Faraday.new(API_URI) do |conn|
-        conn.response :json, content_type: /\bjson\z/
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
       end
     end
 


### PR DESCRIPTION
## 概要
apple_music gemがアーカイブされたため、必要な機能をlib/apple_music/に移植し、faraday gemをv2にアップグレードしました。

## 変更内容
- apple_music gemをGemfileから削除
- faraday gemをv2.13.1にアップグレード  
- lib/apple_music/に独自実装を追加
  - JWT認証トークン生成機能
  - Album/Artist/Song APIクライアント
  - 既存コードとの互換性を保つレスポンスオブジェクト
- line_music/connection.rbもfaraday v2に対応
- Rubocopによるコード整形を適用

## 動作確認
- Apple Music APIのアルバム取得テストが成功することを確認
- Rubocopの全チェックが通ることを確認

## 技術的詳細
- OpenStructを使用してapple_music gemと同じインターフェースを提供
- Faraday v2の新しいミドルウェア構文に対応
- JWT認証は既存の環境変数をそのまま使用