### PR TITLE
LINE MUSIC APIの接続タイムアウト問題を修正

### DIFF
--- a/app/avo/actions/update_line_music_album.rb
+++ b/app/avo/actions/update_line_music_album.rb
@@ -6,18 +6,37 @@ class UpdateLineMusicAlbum < Avo::BaseAction
   self.visible = -> { view == :index }
 
   def handle(_args)
+    updated_count = 0
+    error_count = 0
+
     LineMusicAlbum.find_each do |line_music_album|
+      Rails.logger.info "Fetching LINE MUSIC album: #{line_music_album.line_music_id}"
       lm_album = LineMusic::Album.find(line_music_album.line_music_id)
+
       if lm_album.present?
         line_music_album.update(
           name: lm_album.album_title,
           total_tracks: lm_album.track_total_count,
           payload: lm_album.as_json
         )
+        updated_count += 1
       end
+    rescue Faraday::ConnectionFailed => e
+      Rails.logger.error "Connection failed for album #{line_music_album.line_music_id}: #{e.message}"
+      error_count += 1
+    rescue Faraday::TimeoutError => e
+      Rails.logger.error "Timeout for album #{line_music_album.line_music_id}: #{e.message}"
+      error_count += 1
+    rescue StandardError => e
+      Rails.logger.error "Error updating album #{line_music_album.line_music_id}: #{e.class} - #{e.message}"
+      error_count += 1
     end
 
-    succeed 'Done!'
+    if error_count.positive?
+      warn "更新完了: #{updated_count}件成功、#{error_count}件エラー"
+    else
+      succeed "更新完了: #{updated_count}件成功"
+    end
     reload
   end
 end


### PR DESCRIPTION
## 概要
LINE MUSIC APIへの接続でタイムアウトエラーが頻発していた問題を修正しました。

## 変更内容
- Faradayクライアントにタイムアウト設定を追加
  - 接続タイムアウト: 5秒
  - 読み取りタイムアウト: 10秒
- リトライ機能を実装
  - 最大3回のリトライ
  - リトライ間隔: 30秒（固定）
  - 対象エラー: `Faraday::ConnectionFailed`、`Faraday::TimeoutError`
- UpdateLineMusicAlbumアクションのエラーハンドリングを改善
  - 個別のアルバム更新失敗時も処理を継続
  - エラーログの詳細化
  - 処理結果の集計（成功件数/エラー件数）

## テスト計画
- [ ] Avoの管理画面でLINE MUSICアルバム更新アクションを実行
- [ ] タイムアウトエラーが発生した場合のリトライ動作を確認
- [ ] 部分的なエラー発生時に処理が継続されることを確認
- [ ] ログ出力が適切に行われることを確認