### PR TITLE
原曲紐づけ作業用の管理画面を追加

### DIFF
--- a/app/assets/stylesheets/admin.css
+++ b/app/assets/stylesheets/admin.css
@@ -1168,6 +1168,23 @@
   margin-bottom: 0.28rem;
 }
 
+.admin-checkbox-row {
+  align-items: center;
+  color: var(--admin-text);
+  display: inline-flex;
+  font-size: 0.86rem;
+  font-weight: 750;
+  gap: 0.45rem;
+  min-height: var(--admin-control-height);
+}
+
+.admin-checkbox-row input[type="checkbox"] {
+  accent-color: var(--admin-primary);
+  height: 1rem;
+  margin: 0;
+  width: 1rem;
+}
+
 .admin-view-mode-bar {
   align-items: center;
   display: flex;
@@ -1361,6 +1378,262 @@
 
 .admin-relation-form-row .admin-input {
   min-width: 14rem;
+}
+
+.admin-original-song-assignment-panel .admin-table-scroll {
+  max-height: calc(100vh - 15rem);
+}
+
+.admin-original-song-assignment-search-form .admin-list-toolbar {
+  gap: 0.6rem;
+  padding: 0.7rem;
+}
+
+.admin-original-song-assignment-search-form .admin-filter-bar {
+  align-items: end;
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: minmax(14rem, 1fr) auto;
+  padding: 0.6rem;
+}
+
+.admin-original-song-assignment-search-form .admin-filter-field {
+  min-width: 0;
+}
+
+.admin-original-song-assignment-search-form .admin-list-controls {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(18rem, 36rem) auto;
+}
+
+.admin-original-song-assignment-search-form .admin-search-row {
+  min-width: 0;
+}
+
+.admin-original-song-assignment-search-form .admin-search-row .admin-search-input {
+  flex: 0 0 24rem;
+}
+
+.admin-original-song-assignment-search-form .admin-record-count {
+  align-self: center;
+  display: flex;
+  gap: 0.45rem;
+  justify-self: end;
+  margin-left: 0;
+  min-height: var(--admin-control-height);
+  padding: 0.45rem 0.65rem;
+}
+
+.admin-original-song-assignment-search-form .admin-record-count span,
+.admin-original-song-assignment-search-form .admin-record-count strong {
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.admin-original-song-assignment-table {
+  min-width: 76rem;
+}
+
+.admin-original-song-assignment-table td:last-child,
+.admin-original-song-assignment-table th:last-child {
+  min-width: 28rem;
+  position: static;
+}
+
+.admin-original-song-picker {
+  display: grid;
+  gap: 0.5rem;
+  min-width: 24rem;
+}
+
+.admin-original-song-selected {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  min-height: 2rem;
+}
+
+.admin-original-song-empty-selection {
+  color: var(--admin-muted);
+  font-size: 0.86rem;
+}
+
+.admin-original-song-chip {
+  align-items: center;
+  background: var(--admin-primary-soft);
+  border: 1px solid var(--admin-border);
+  border-radius: 8px;
+  color: var(--admin-text);
+  display: inline-flex;
+  font-size: 0.82rem;
+  font-weight: 700;
+  gap: 0.35rem;
+  line-height: 1.35;
+  max-width: 100%;
+  min-height: 1.8rem;
+  padding: 0.22rem 0.35rem 0.22rem 0.55rem;
+}
+
+.admin-original-song-chip span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-original-song-chip-remove {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--admin-muted);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 1rem;
+  font-weight: 800;
+  height: 1.35rem;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  width: 1.35rem;
+}
+
+.admin-original-song-chip-remove:hover,
+.admin-original-song-chip-remove:focus {
+  background: rgba(180, 35, 24, 0.12);
+  color: var(--admin-danger);
+}
+
+.admin-original-song-search {
+  position: relative;
+}
+
+.admin-original-song-search .admin-icon {
+  color: var(--admin-muted);
+  height: 1rem;
+  left: 0.75rem;
+  pointer-events: none;
+  position: absolute;
+  top: 0.72rem;
+  width: 1rem;
+  z-index: 1;
+}
+
+.admin-original-song-search-input {
+  padding-left: 2.2rem;
+  width: 100%;
+}
+
+.admin-original-song-listbox {
+  background: var(--admin-surface);
+  border: 1px solid var(--admin-border);
+  border-radius: 8px;
+  box-shadow: var(--admin-shadow);
+  left: 0;
+  margin-top: 0.3rem;
+  max-height: 16rem;
+  overflow: auto;
+  position: absolute;
+  right: 0;
+  z-index: 20;
+}
+
+.admin-original-song-option,
+.admin-original-song-option-empty {
+  background: transparent;
+  border: 0;
+  color: var(--admin-text);
+  display: block;
+  font-size: 0.86rem;
+  line-height: 1.35;
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  width: 100%;
+}
+
+.admin-original-song-option {
+  cursor: pointer;
+}
+
+.admin-original-song-option-query {
+  color: var(--admin-muted);
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 800;
+  margin-bottom: 0.18rem;
+}
+
+.admin-original-song-option:hover,
+.admin-original-song-option.is-active {
+  background: var(--admin-primary-soft);
+  color: var(--admin-text);
+}
+
+.admin-original-song-option-empty {
+  color: var(--admin-muted);
+}
+
+.admin-original-song-missing-query {
+  background: var(--admin-surface-muted);
+  border-top: 1px solid var(--admin-border);
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.7rem 0.75rem;
+}
+
+.admin-original-song-missing-query:first-child {
+  border-top: 0;
+}
+
+.admin-original-song-missing-label {
+  color: var(--admin-muted);
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.admin-original-song-missing-controls {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.admin-original-song-missing-input {
+  flex: 1 1 auto;
+  height: 2.15rem;
+  min-width: 0;
+  padding-inline: 0.65rem;
+}
+
+.admin-original-song-missing-input:focus {
+  outline-offset: 1px;
+}
+
+.admin-original-song-missing-button {
+  align-items: center;
+  background: var(--admin-surface);
+  border: 1px solid var(--admin-border);
+  border-radius: 8px;
+  color: var(--admin-text);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 0.82rem;
+  font-weight: 800;
+  min-height: 2.15rem;
+  padding: 0.35rem 0.65rem;
+  white-space: nowrap;
+}
+
+.admin-original-song-missing-button:hover,
+.admin-original-song-missing-button:focus {
+  background: var(--admin-primary-soft);
+  border-color: var(--admin-border-strong);
 }
 
 .admin-row-actions {
@@ -2772,6 +3045,10 @@
 }
 
 .admin-search-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  gap: 0.65rem;
   justify-content: end;
 }
 
@@ -3055,6 +3332,7 @@
   }
 
   .admin-search-actions {
+    flex-wrap: wrap;
     justify-content: stretch;
   }
 }
@@ -3984,6 +4262,13 @@ html[data-admin-resolved-theme="light"] .admin-pagination-gap {
   display: flex;
   gap: 0.65rem;
   min-width: min(100%, 28rem);
+  width: 100%;
+}
+
+.admin-search-row .admin-search-input {
+  flex: 1 1 24rem;
+  margin-bottom: 0;
+  min-width: 16rem;
 }
 
 .admin-search-form .admin-filter-bar {
@@ -4170,6 +4455,15 @@ html[data-admin-resolved-theme="light"] .admin-filter-chip strong {
 
   .admin-search-actions {
     justify-content: stretch;
+  }
+
+  .admin-original-song-assignment-search-form .admin-filter-bar,
+  .admin-original-song-assignment-search-form .admin-list-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-original-song-assignment-search-form .admin-record-count {
+    justify-self: stretch;
   }
 
   .admin-search-input {

--- a/app/assets/stylesheets/admin.css
+++ b/app/assets/stylesheets/admin.css
@@ -1442,6 +1442,31 @@
   position: static;
 }
 
+.admin-original-song-missing-albums-search-form .admin-list-controls {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(18rem, 36rem) auto auto;
+}
+
+.admin-original-song-missing-albums-copy {
+  align-items: center;
+  display: flex;
+  gap: 0.55rem;
+  justify-self: end;
+}
+
+.admin-original-song-missing-albums-table {
+  min-width: 64rem;
+}
+
+.admin-copy-status {
+  color: var(--admin-muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  min-width: 7rem;
+}
+
 .admin-original-song-picker {
   display: grid;
   gap: 0.5rem;
@@ -4458,11 +4483,13 @@ html[data-admin-resolved-theme="light"] .admin-filter-chip strong {
   }
 
   .admin-original-song-assignment-search-form .admin-filter-bar,
-  .admin-original-song-assignment-search-form .admin-list-controls {
+  .admin-original-song-assignment-search-form .admin-list-controls,
+  .admin-original-song-missing-albums-search-form .admin-list-controls {
     grid-template-columns: 1fr;
   }
 
-  .admin-original-song-assignment-search-form .admin-record-count {
+  .admin-original-song-assignment-search-form .admin-record-count,
+  .admin-original-song-missing-albums-copy {
     justify-self: stretch;
   }
 

--- a/app/controllers/admin/original_song_assignments_controller.rb
+++ b/app/controllers/admin/original_song_assignments_controller.rb
@@ -1,0 +1,300 @@
+# frozen_string_literal: true
+
+module Admin
+  class OriginalSongAssignmentsController < BaseController
+    before_action :authenticate_admin_if_configured
+
+    STATUS_OPTIONS = %w[missing present all].freeze
+
+    def index
+      @track_resource = Admin::Resource.find!('tracks')
+      @query = params.fetch(:q, '').to_s.strip
+      @status = normalized_status
+      @show_identifiers = show_identifiers?
+      @pagy, @tracks = pagy(:offset, assignment_scope, limit: Admin::Resource::DEFAULT_ITEMS)
+    end
+
+    def update
+      errors = update_assignments
+
+      if errors.empty?
+        redirect_to admin_track_original_song_assignments_path(redirect_filter_params),
+                    notice: t('admin.original_song_assignments.update_success')
+      else
+        redirect_to admin_track_original_song_assignments_path(redirect_filter_params),
+                    alert: errors.join("\n")
+      end
+    end
+
+    def options
+      render json: { options: original_song_options }
+    end
+
+    def resolve
+      render json: { resolutions: pasted_original_song_resolutions }
+    end
+
+    private
+
+    def assignment_scope
+      scope = @track_resource.apply_to(Track.all).reorder(nil)
+      scope = @track_resource.search(scope, @query)
+      scope = filter_by_status(scope)
+      order_assignment_scope(scope)
+    end
+
+    def filter_by_status(scope)
+      case @status
+      when 'missing'
+        scope.where(id: Track.missing_original_songs.select(:id))
+      when 'present'
+        scope.where(id: Track.where.associated(:original_songs).distinct.select(:id))
+      else
+        scope
+      end
+    end
+
+    def order_assignment_scope(scope)
+      scope.reorder(
+        Arel.sql("#{Track.quoted_table_name}.#{Track.connection.quote_column_name(:jan_code)} DESC"),
+        Arel.sql("#{assignment_disc_number_sql} ASC"),
+        Arel.sql("#{assignment_track_number_sql} ASC"),
+        Arel.sql("#{Track.quoted_table_name}.#{Track.connection.quote_column_name(:isrc)} ASC")
+      )
+    end
+
+    def assignment_disc_number_sql
+      <<~SQL.squish
+        COALESCE(
+          (#{active_spotify_track_position_sql(:disc_number)}),
+          (#{streaming_track_position_sql(AppleMusicTrack, :disc_number)}),
+          (#{streaming_track_position_sql(LineMusicTrack, :disc_number)}),
+          (#{streaming_track_position_sql(SpotifyTrack, :disc_number)}),
+          1
+        )
+      SQL
+    end
+
+    def assignment_track_number_sql
+      <<~SQL.squish
+        COALESCE(
+          (#{active_spotify_track_position_sql(:track_number)}),
+          (#{streaming_track_position_sql(AppleMusicTrack, :track_number)}),
+          (#{streaming_track_position_sql(LineMusicTrack, :track_number)}),
+          (#{streaming_track_position_sql(YtmusicTrack, :track_number)}),
+          (#{streaming_track_position_sql(SpotifyTrack, :track_number)}),
+          2147483647
+        )
+      SQL
+    end
+
+    def active_spotify_track_position_sql(column)
+      spotify_tracks_table = SpotifyTrack.quoted_table_name
+      spotify_albums_table = SpotifyAlbum.quoted_table_name
+      <<~SQL.squish
+        SELECT MIN(#{spotify_tracks_table}.#{SpotifyTrack.connection.quote_column_name(column)})
+        FROM #{spotify_tracks_table}
+        INNER JOIN #{spotify_albums_table}
+          ON #{spotify_albums_table}.#{SpotifyAlbum.connection.quote_column_name(:id)}
+           = #{spotify_tracks_table}.#{SpotifyTrack.connection.quote_column_name(:spotify_album_id)}
+        WHERE #{spotify_tracks_table}.#{SpotifyTrack.connection.quote_column_name(:track_id)}
+          = #{Track.quoted_table_name}.#{Track.connection.quote_column_name(:id)}
+          AND #{spotify_albums_table}.#{SpotifyAlbum.connection.quote_column_name(:active)} = TRUE
+      SQL
+    end
+
+    def streaming_track_position_sql(model_class, column)
+      table = model_class.quoted_table_name
+      <<~SQL.squish
+        SELECT MIN(#{table}.#{model_class.connection.quote_column_name(column)})
+        FROM #{table}
+        WHERE #{table}.#{model_class.connection.quote_column_name(:track_id)}
+          = #{Track.quoted_table_name}.#{Track.connection.quote_column_name(:id)}
+      SQL
+    end
+
+    def normalized_status
+      status = params.fetch(:status, 'missing').to_s
+      STATUS_OPTIONS.include?(status) ? status : 'missing'
+    end
+
+    def show_identifiers?
+      Array(params.fetch(:show_identifiers, '0')).map(&:to_s).include?('1')
+    end
+
+    def update_assignments
+      errors = []
+      assignments = assignment_params
+      return [t('admin.original_song_assignments.no_assignments')] if assignments.empty?
+
+      tracks = Track.where(id: assignments.keys).index_by { |track| track.id.to_s }
+
+      Track.transaction do
+        assignments.each do |track_id, assignment|
+          track = tracks[track_id.to_s]
+          if track.blank?
+            errors << t('admin.original_song_assignments.track_not_found', id: track_id)
+            next
+          end
+
+          codes = normalize_original_song_codes(assignment['original_song_codes'])
+          original_songs = OriginalSong.non_duplicated.where(code: codes).index_by(&:code)
+          missing_codes = codes - original_songs.keys
+          if missing_codes.any?
+            errors << t('admin.original_song_assignments.original_songs_not_found', isrc: track.isrc, codes: missing_codes.join(', '))
+            next
+          end
+
+          track.original_songs = codes.map { |code| original_songs.fetch(code) }
+        end
+
+        raise ActiveRecord::Rollback if errors.any?
+      end
+
+      errors
+    end
+
+    def assignment_params
+      assignments = params.fetch(:assignments, {})
+      assignments.respond_to?(:to_unsafe_h) ? assignments.to_unsafe_h : assignments.to_h
+    end
+
+    def normalize_original_song_codes(value)
+      value.to_s.split(%r{[\s,/]+}).map(&:strip).compact_blank.uniq
+    end
+
+    def original_song_options
+      original_song_scope.limit(Admin::Resource::FORM_ASSOCIATION_AUTOCOMPLETE_LIMIT).map do |original_song|
+        original_song_option(original_song)
+      end
+    end
+
+    def pasted_original_song_resolutions
+      pasted_original_song_queries.map do |query|
+        {
+          query:,
+          options: candidate_original_songs(query).limit(10).map { |original_song| original_song_option(original_song) }
+        }
+      end
+    end
+
+    def pasted_original_song_queries
+      params.fetch(:text, '').to_s.split(%r{[,\n\r、，/／]+}).map do |query|
+        normalize_pasted_original_song_query(query)
+      end.compact_blank.uniq.first(30)
+    end
+
+    def normalize_pasted_original_song_query(query)
+      query.to_s
+           .strip
+           .then { |value| value.match?(/\A["'`]{3,}\z/) ? '' : value }
+           .sub(/\A原曲\s*[:：]\s*/, '')
+           .strip
+    end
+
+    def candidate_original_songs(query)
+      exact_code_scope = original_song_base_scope.where(code: query)
+      return exact_code_scope.order(:original_code, :track_number, :code) if exact_code_scope.exists?
+
+      exact_title_scope = original_song_base_scope.where(title: query)
+      return exact_title_scope.order(:original_code, :track_number, :code) if exact_title_scope.exists?
+
+      search_original_songs(original_song_base_scope, query).order(:original_code, :track_number, :code)
+    end
+
+    def original_song_scope
+      query = params.fetch(:q, '').to_s.strip
+      scope = original_song_base_scope
+      scope = search_original_songs(scope, query) if query.present?
+      scope.order(:original_code, :track_number, :code)
+    end
+
+    def original_song_base_scope
+      OriginalSong.non_duplicated.includes(:original)
+    end
+
+    def search_original_songs(scope, query)
+      pattern = "%#{OriginalSong.sanitize_sql_like(query)}%"
+      normalized_terms = normalized_original_song_query(query).split.flat_map do |term|
+        normalized_original_song_search_terms(term)
+      end
+      conditions = {
+        query: pattern
+      }
+      normalized_term_clause = normalized_terms.each_with_index.map do |term, index|
+        conditions[:"normalized_term_#{index}"] = "%#{OriginalSong.sanitize_sql_like(term)}%"
+        if term == '～'
+          conditions[:"normalized_term_ascii_#{index}"] = '%~%'
+          term_conditions = <<~SQL.squish
+            (
+              original_songs.title ILIKE :normalized_term_#{index} OR
+              original_songs.title ILIKE :normalized_term_ascii_#{index} OR
+              originals.title ILIKE :normalized_term_#{index} OR
+              originals.title ILIKE :normalized_term_ascii_#{index} OR
+              originals.short_title ILIKE :normalized_term_#{index} OR
+              originals.short_title ILIKE :normalized_term_ascii_#{index}
+            )
+          SQL
+          next term_conditions
+        end
+
+        <<~SQL.squish
+          (
+            original_songs.title ILIKE :normalized_term_#{index} OR
+            originals.title ILIKE :normalized_term_#{index} OR
+            originals.short_title ILIKE :normalized_term_#{index}
+          )
+        SQL
+      end.join(' AND ')
+      normalized_term_sql = normalized_term_clause.present? ? "OR (#{normalized_term_clause})" : nil
+
+      scope.left_joins(:original).where(
+        <<~SQL.squish,
+          (
+            original_songs.code ILIKE :query OR
+            original_songs.title ILIKE :query OR
+            original_songs.composer ILIKE :query OR
+            originals.title ILIKE :query OR
+            originals.short_title ILIKE :query
+          )
+          #{normalized_term_sql}
+        SQL
+        conditions
+      )
+    end
+
+    def normalized_original_song_query(query)
+      query.to_s
+           .tr('　', ' ')
+           .gsub(/[~〜～]/, ' ～ ')
+           .squish
+    end
+
+    def normalized_original_song_search_terms(term)
+      punctuation_normalized_term = term.delete('?!？！')
+      return [punctuation_normalized_term] if punctuation_normalized_term.present?
+
+      [term]
+    end
+
+    def original_song_label(original_song)
+      [
+        original_song.code,
+        original_song.title,
+        original_song.original_title,
+        original_song.composer
+      ].compact_blank.uniq.join(' / ')
+    end
+
+    def original_song_option(original_song)
+      {
+        value: original_song.code,
+        label: original_song_label(original_song)
+      }
+    end
+
+    def redirect_filter_params
+      params.permit(:q, :status, :show_identifiers).to_h.compact_blank
+    end
+  end
+end

--- a/app/controllers/admin/original_song_assignments_controller.rb
+++ b/app/controllers/admin/original_song_assignments_controller.rb
@@ -5,6 +5,7 @@ module Admin
     before_action :authenticate_admin_if_configured
 
     STATUS_OPTIONS = %w[missing present all].freeze
+    PASTED_ORIGINAL_SONG_DELIMITER_PATTERN = %r{[,、，/／]+}
 
     def index
       @track_resource = Admin::Resource.find!('tracks')
@@ -179,9 +180,55 @@ module Admin
     end
 
     def pasted_original_song_queries
-      params.fetch(:text, '').to_s.split(%r{[,\n\r、，/／]+}).map do |query|
-        normalize_pasted_original_song_query(query)
+      params.fetch(:text, '').to_s.each_line.flat_map do |line|
+        pasted_original_song_queries_from_line(line)
       end.compact_blank.uniq.first(30)
+    end
+
+    def pasted_original_song_queries_from_line(line)
+      query = normalize_pasted_original_song_query(line)
+      return [] if query.blank?
+
+      split_pasted_original_song_query(query)
+    end
+
+    def split_pasted_original_song_query(query)
+      return [query] if candidate_original_songs(query).exists?
+
+      fragments = query.split(PASTED_ORIGINAL_SONG_DELIMITER_PATTERN)
+      return [query] if fragments.map { |fragment| normalize_pasted_original_song_query(fragment) }.compact_blank.one?
+
+      delimiters = query.scan(PASTED_ORIGINAL_SONG_DELIMITER_PATTERN)
+      queries = []
+      fragment_index = 0
+      while fragment_index < fragments.length
+        match = longest_pasted_original_song_query_match(fragments, delimiters, fragment_index)
+        if match.present?
+          queries << match.fetch(:query)
+          fragment_index = match.fetch(:next_index)
+        else
+          queries << normalize_pasted_original_song_query(fragments.fetch(fragment_index))
+          fragment_index += 1
+        end
+      end
+      queries
+    end
+
+    def longest_pasted_original_song_query_match(fragments, delimiters, start_index)
+      (fragments.length - 1).downto(start_index) do |end_index|
+        query = joined_pasted_original_song_query(fragments, delimiters, start_index, end_index)
+        return { query:, next_index: end_index + 1 } if candidate_original_songs(query).exists?
+      end
+
+      nil
+    end
+
+    def joined_pasted_original_song_query(fragments, delimiters, start_index, end_index)
+      query = (start_index..end_index).each_with_object(+'') do |fragment_index, joined_query|
+        joined_query << delimiters.fetch(fragment_index - 1, '') if fragment_index > start_index
+        joined_query << fragments.fetch(fragment_index)
+      end
+      normalize_pasted_original_song_query(query)
     end
 
     def normalize_pasted_original_song_query(query)

--- a/app/controllers/admin/original_song_missing_albums_controller.rb
+++ b/app/controllers/admin/original_song_missing_albums_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Admin
+  class OriginalSongMissingAlbumsController < BaseController
+    before_action :authenticate_admin_if_configured
+
+    def index
+      @album_resource = Admin::Resource.find!('albums')
+      @query = params.fetch(:q, '').to_s.strip
+      @pagy, @albums = pagy(:offset, album_scope, limit: Admin::Resource::DEFAULT_ITEMS)
+      @missing_track_counts = missing_track_counts(@albums)
+      @copy_text = copy_text_for(copy_scope)
+    end
+
+    private
+
+    def album_scope
+      search_albums(base_scope, @query).order(jan_code: :desc)
+    end
+
+    def copy_scope
+      search_albums(base_scope, @query).order(jan_code: :desc)
+    end
+
+    def base_scope
+      Album
+        .tracks_missing_original_songs
+        .includes(:circles, :spotify_album, :apple_music_album, :ytmusic_album, :line_music_album)
+        .distinct
+    end
+
+    def search_albums(scope, query)
+      return scope if query.blank?
+
+      pattern = "%#{Album.sanitize_sql_like(query)}%"
+      scope.left_joins(:circles, :spotify_album, :apple_music_album, :ytmusic_album, :line_music_album).where(
+        <<~SQL.squish,
+          albums.jan_code ILIKE :query OR
+          circles.name ILIKE :query OR
+          spotify_albums.name ILIKE :query OR
+          apple_music_albums.name ILIKE :query OR
+          ytmusic_albums.name ILIKE :query OR
+          line_music_albums.name ILIKE :query
+        SQL
+        query: pattern
+      ).distinct
+    end
+
+    def missing_track_counts(albums)
+      Track
+        .missing_original_songs
+        .where(jan_code: albums.map(&:jan_code))
+        .group(:jan_code)
+        .count
+    end
+
+    def copy_text_for(scope)
+      scope.map { |album| [album.circle_name, album_name(album)].join("\t") }.join("\n")
+    end
+
+    def album_name(album)
+      album.spotify_album_name || album.apple_music_album_name || album.ytmusic_album_name || album.line_music_album_name || album.jan_code
+    end
+    helper_method :album_name
+  end
+end

--- a/app/helpers/admin/icons_helper.rb
+++ b/app/helpers/admin/icons_helper.rb
@@ -15,6 +15,7 @@ module Admin
       chevron_right: ['M9 18l6-6-6-6'],
       chevron_up: ['M18 15l-6-6-6 6'],
       collection: ['M4 6h16', 'M4 12h16', 'M4 18h16'],
+      copy: ['M8 8h11a1 1 0 0 1 1 1v11a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1Z', 'M4 16H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h11a1 1 0 0 1 1 1v1'],
       dashboard: ['M4 13a8 8 0 1 1 16 0', 'M12 13l4-4', 'M5 19h14'],
       download: ['M12 3v12', 'M7 10l5 5 5-5', 'M5 21h14'],
       edit: ['M12 20h9', 'M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z'],

--- a/app/javascript/controllers/admin_clipboard_controller.js
+++ b/app/javascript/controllers/admin_clipboard_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["source", "status"]
+
+  async copy() {
+    const text = this.sourceTarget.value
+    if (!text) return
+
+    try {
+      await this.writeText(text)
+      this.showStatus("コピーしました")
+    } catch (_error) {
+      this.showStatus("コピーできませんでした")
+    }
+  }
+
+  async writeText(text) {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return
+    }
+
+    this.sourceTarget.hidden = false
+    this.sourceTarget.focus()
+    this.sourceTarget.select()
+    document.execCommand("copy")
+    this.sourceTarget.hidden = true
+  }
+
+  showStatus(message) {
+    if (!this.hasStatusTarget) return
+
+    this.statusTarget.textContent = message
+    clearTimeout(this.statusTimer)
+    this.statusTimer = setTimeout(() => {
+      this.statusTarget.textContent = ""
+    }, 2500)
+  }
+}

--- a/app/javascript/controllers/admin_original_song_picker_controller.js
+++ b/app/javascript/controllers/admin_original_song_picker_controller.js
@@ -1,0 +1,504 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["hidden", "input", "listbox", "selected"]
+  static values = {
+    url: String,
+    resolveUrl: String,
+    initialOptions: Array
+  }
+
+  connect() {
+    this.selectedOptions = this.hasInitialOptionsValue ? [...this.initialOptionsValue] : []
+    this.activeIndex = -1
+    this.loadedQuery = null
+    this.requestSequence = 0
+    this.resolveRowPasteHandler = (event) => this.resolvePastedRow(event)
+    this.element.addEventListener("admin-original-song-picker:resolve-row", this.resolveRowPasteHandler)
+    this.renderSelectedOptions()
+    this.syncHiddenValue()
+    this.close()
+  }
+
+  disconnect() {
+    clearTimeout(this.searchTimer)
+    clearTimeout(this.missingQueryTimer)
+    this.element.removeEventListener("admin-original-song-picker:resolve-row", this.resolveRowPasteHandler)
+  }
+
+  focus() {
+    this.open()
+    this.loadOptions(this.inputTarget.value, { activateFirst: false })
+  }
+
+  filter() {
+    this.open()
+    clearTimeout(this.searchTimer)
+    this.searchTimer = setTimeout(() => {
+      this.loadOptions(this.inputTarget.value, { activateFirst: true })
+    }, 150)
+  }
+
+  keydown(event) {
+    const visibleOptions = this.visibleOptions()
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      this.open()
+      this.activeIndex = Math.min(this.activeIndex + 1, visibleOptions.length - 1)
+      this.updateActiveOption()
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      this.open()
+      this.activeIndex = Math.max(this.activeIndex - 1, 0)
+      this.updateActiveOption()
+    } else if (event.key === "Enter" && this.activeIndex >= 0) {
+      event.preventDefault()
+      this.selectOption(visibleOptions[this.activeIndex])
+    } else if (event.key === "Escape") {
+      this.close()
+    }
+  }
+
+  blur() {
+    setTimeout(() => {
+      if (this.element.contains(document.activeElement)) return
+
+      this.close()
+    }, 120)
+  }
+
+  choose(event) {
+    event.preventDefault()
+    this.selectOption(event.currentTarget)
+  }
+
+  retryMissingQuery(event) {
+    event.preventDefault()
+    const input = this.missingQueryInputFor(event.currentTarget)
+    if (!input) return
+
+    this.resolveEditedMissingQuery(input, { preserveMissingOnEmpty: false })
+  }
+
+  keydownMissingQuery(event) {
+    if (event.key === "Enter") {
+      this.retryMissingQuery(event)
+    } else if (event.key === "Escape") {
+      this.close()
+      this.inputTarget.focus()
+    }
+  }
+
+  filterMissingQuery(event) {
+    const input = event.currentTarget
+    clearTimeout(this.missingQueryTimer)
+    this.missingQueryTimer = setTimeout(() => {
+      this.resolveEditedMissingQuery(input, { preserveMissingOnEmpty: true })
+    }, 250)
+  }
+
+  paste(event) {
+    const text = event.clipboardData?.getData("text")
+    if (!text || !this.hasResolveUrlValue) return
+
+    event.preventDefault()
+    if (this.pastedRows(text).length > 1) {
+      this.resolvePastedRows(text)
+    } else {
+      this.resolvePastedText(text.trim())
+    }
+  }
+
+  resolvePastedRow(event) {
+    event.preventDefault()
+    const text = event.detail?.text?.trim()
+    if (!text) return
+
+    this.resolvePastedText(text)
+  }
+
+  remove(event) {
+    event.preventDefault()
+    const value = event.currentTarget.dataset.value
+    this.selectedOptions = this.selectedOptions.filter((option) => option.value !== value)
+    this.renderSelectedOptions()
+    this.syncHiddenValue()
+    this.renderOptions(this.currentOptions || [], { activateFirst: false })
+  }
+
+  open() {
+    this.listboxTarget.hidden = false
+    this.inputTarget.setAttribute("aria-expanded", "true")
+  }
+
+  close() {
+    this.listboxTarget.hidden = true
+    this.inputTarget.setAttribute("aria-expanded", "false")
+    this.activeIndex = -1
+    this.updateActiveOption()
+  }
+
+  async loadOptions(query, { activateFirst }) {
+    if (!this.hasUrlValue || this.loadedQuery === query) {
+      this.activeIndex = activateFirst && this.visibleOptions().length > 0 ? 0 : -1
+      this.updateActiveOption()
+      return
+    }
+
+    const requestId = this.requestSequence + 1
+    this.requestSequence = requestId
+    this.listboxTarget.setAttribute("aria-busy", "true")
+
+    try {
+      const url = new URL(this.urlValue, window.location.origin)
+      url.searchParams.set("q", query)
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Accept: "application/json"
+        }
+      })
+
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      if (requestId !== this.requestSequence) return
+
+      const data = await response.json()
+      this.loadedQuery = query
+      this.currentOptions = data.options || []
+      this.renderOptions(this.currentOptions, { activateFirst })
+    } catch (_error) {
+      if (requestId === this.requestSequence) {
+        this.renderOptions([], { activateFirst: false })
+      }
+    } finally {
+      if (requestId === this.requestSequence) {
+        this.listboxTarget.removeAttribute("aria-busy")
+      }
+    }
+  }
+
+  async resolvePastedText(text) {
+    const requestId = this.requestSequence + 1
+    this.requestSequence = requestId
+    this.open()
+    this.listboxTarget.setAttribute("aria-busy", "true")
+
+    try {
+      const url = new URL(this.resolveUrlValue, window.location.origin)
+      url.searchParams.set("text", text)
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Accept: "application/json"
+        }
+      })
+
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      if (requestId !== this.requestSequence) return
+
+      const data = await response.json()
+      this.inputTarget.value = ""
+      this.loadedQuery = null
+      this.renderResolvedOptions(data.resolutions || [])
+    } catch (_error) {
+      if (requestId === this.requestSequence) {
+        this.renderOptions([], { activateFirst: false })
+      }
+    } finally {
+      if (requestId === this.requestSequence) {
+        this.listboxTarget.removeAttribute("aria-busy")
+      }
+    }
+  }
+
+  async resolveEditedMissingQuery(input, { preserveMissingOnEmpty }) {
+    const query = input.value.trim()
+    if (!query) return
+
+    const requestId = this.requestSequence + 1
+    this.requestSequence = requestId
+    this.open()
+    this.listboxTarget.setAttribute("aria-busy", "true")
+
+    try {
+      const url = new URL(this.resolveUrlValue, window.location.origin)
+      url.searchParams.set("text", query)
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Accept: "application/json"
+        }
+      })
+
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      if (requestId !== this.requestSequence) return
+
+      const data = await response.json()
+      const resolutions = data.resolutions || []
+      const hasOptions = resolutions.some((resolution) => (resolution.options || []).length > 0)
+      if (preserveMissingOnEmpty && !hasOptions) return
+
+      this.inputTarget.value = ""
+      this.loadedQuery = null
+      this.renderResolvedOptions(resolutions)
+    } catch (_error) {
+      if (!preserveMissingOnEmpty && requestId === this.requestSequence) {
+        this.renderOptions([], { activateFirst: false })
+      }
+    } finally {
+      if (requestId === this.requestSequence) {
+        this.listboxTarget.removeAttribute("aria-busy")
+      }
+    }
+  }
+
+  selectOption(optionElement) {
+    if (!optionElement) return
+
+    this.addOption({
+      value: optionElement.dataset.value,
+      label: optionElement.dataset.label
+    })
+
+    this.inputTarget.value = ""
+    this.loadedQuery = null
+    this.renderSelectedOptions()
+    this.syncHiddenValue()
+    this.renderOptions(this.currentOptions || [], { activateFirst: false })
+    this.inputTarget.focus()
+  }
+
+  addOption(option) {
+    if (!option?.value || this.selectedOptions.some((selectedOption) => selectedOption.value === option.value)) return
+
+    this.selectedOptions = [...this.selectedOptions, option]
+  }
+
+  renderSelectedOptions() {
+    if (this.selectedOptions.length === 0) {
+      const empty = document.createElement("span")
+      empty.className = "admin-original-song-empty-selection"
+      empty.textContent = "未設定"
+      this.selectedTarget.replaceChildren(empty)
+      return
+    }
+
+    this.selectedTarget.replaceChildren(...this.selectedOptions.map((option) => this.buildSelectedOption(option)))
+  }
+
+  buildSelectedOption(option) {
+    const chip = document.createElement("span")
+    chip.className = "admin-original-song-chip"
+
+    const label = document.createElement("span")
+    label.textContent = option.label
+
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className = "admin-original-song-chip-remove"
+    button.dataset.value = option.value
+    button.dataset.action = "admin-original-song-picker#remove"
+    button.setAttribute("aria-label", `${option.label}を削除`)
+    button.textContent = "×"
+
+    chip.append(label, button)
+    return chip
+  }
+
+  renderOptions(options, { activateFirst }) {
+    const availableOptions = options.filter((option) => (
+      !this.selectedOptions.some((selectedOption) => selectedOption.value === option.value)
+    ))
+
+    if (availableOptions.length === 0) {
+      const empty = document.createElement("div")
+      empty.className = "admin-original-song-option-empty"
+      empty.textContent = "候補がありません"
+      this.listboxTarget.replaceChildren(empty)
+      this.activeIndex = -1
+      return
+    }
+
+    this.listboxTarget.replaceChildren(...availableOptions.map((option) => this.buildOption(option)))
+    this.activeIndex = activateFirst ? 0 : -1
+    this.updateActiveOption()
+  }
+
+  renderResolvedOptions(resolutions) {
+    const ambiguousOptions = []
+    const missingQueries = []
+
+    resolutions.forEach((resolution) => {
+      const options = resolution.options || []
+
+      if (options.length === 1) {
+        this.addOption(options[0])
+      } else if (options.length > 1) {
+        options.forEach((option) => {
+          ambiguousOptions.push({ ...option, groupLabel: resolution.query })
+        })
+      } else {
+        missingQueries.push(resolution.query)
+      }
+    })
+
+    this.renderSelectedOptions()
+    this.syncHiddenValue()
+
+    if (ambiguousOptions.length > 0 || missingQueries.length > 0) {
+      this.renderResolvedChoiceList(ambiguousOptions, missingQueries)
+      return
+    }
+
+    this.close()
+  }
+
+  renderResolvedChoiceList(options, missingQueries) {
+    const availableOptions = options.filter((option) => (
+      !this.selectedOptions.some((selectedOption) => selectedOption.value === option.value)
+    ))
+    const optionElements = availableOptions.map((option) => this.buildOption(option))
+    const missingQueryElements = missingQueries.map((query) => this.buildMissingQuery(query))
+
+    this.currentOptions = options
+    this.listboxTarget.replaceChildren(...optionElements, ...missingQueryElements)
+    this.activeIndex = optionElements.length > 0 ? 0 : -1
+    this.updateActiveOption()
+  }
+
+  buildMissingQuery(query) {
+    const container = document.createElement("div")
+    container.className = "admin-original-song-missing-query"
+
+    const label = document.createElement("label")
+    label.className = "admin-original-song-missing-label"
+    label.textContent = "候補が見つかりません"
+
+    const controls = document.createElement("div")
+    controls.className = "admin-original-song-missing-controls"
+
+    const input = document.createElement("input")
+    input.type = "search"
+    input.className = "input admin-input admin-original-song-missing-input"
+    input.value = query
+    input.setAttribute("aria-label", "候補が見つからなかった原曲名を修正")
+    input.dataset.action = [
+      "input->admin-original-song-picker#filterMissingQuery",
+      "keydown->admin-original-song-picker#keydownMissingQuery"
+    ].join(" ")
+
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className = "admin-original-song-missing-button"
+    button.dataset.action = "click->admin-original-song-picker#retryMissingQuery"
+    button.textContent = "候補検索"
+
+    controls.append(input, button)
+    container.append(label, controls)
+    return container
+  }
+
+  buildOption(option) {
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className = "admin-original-song-option"
+    button.setAttribute("role", "option")
+    button.setAttribute("aria-selected", "false")
+    button.setAttribute("data-admin-original-song-picker-target", "option")
+    button.setAttribute("data-action", "mousedown->admin-original-song-picker#choose")
+    button.dataset.value = option.value
+    button.dataset.label = option.label
+    if (option.groupLabel) {
+      const query = document.createElement("span")
+      query.className = "admin-original-song-option-query"
+      query.textContent = option.groupLabel
+
+      const label = document.createElement("span")
+      label.textContent = option.label
+      button.append(query, label)
+    } else {
+      button.textContent = option.label
+    }
+    return button
+  }
+
+  updateActiveOption() {
+    const visibleOptions = this.visibleOptions()
+
+    visibleOptions.forEach((option) => {
+      option.classList.remove("is-active")
+      option.setAttribute("aria-selected", "false")
+    })
+
+    const activeOption = visibleOptions[this.activeIndex]
+    if (!activeOption) return
+
+    activeOption.classList.add("is-active")
+    activeOption.setAttribute("aria-selected", "true")
+    activeOption.scrollIntoView({ block: "nearest" })
+  }
+
+  visibleOptions() {
+    return Array.from(this.listboxTarget.querySelectorAll(".admin-original-song-option"))
+  }
+
+  resolvePastedRows(text) {
+    const rows = this.pastedRows(text)
+    const pickerElements = Array.from(document.querySelectorAll('[data-controller~="admin-original-song-picker"]'))
+    const startIndex = pickerElements.indexOf(this.element)
+    if (startIndex < 0) return
+
+    rows.forEach((rowText, offset) => {
+      if (!rowText) return
+
+      const pickerElement = pickerElements[startIndex + offset]
+      if (!pickerElement) return
+
+      pickerElement.dispatchEvent(new CustomEvent("admin-original-song-picker:resolve-row", {
+        detail: { text: rowText }
+      }))
+    })
+  }
+
+  pastedRows(text) {
+    const rows = text
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n")
+      .split("\n")
+      .map((row) => this.pastedRowValue(row))
+
+    while (rows.length > 0 && rows[0] === "") {
+      rows.shift()
+    }
+
+    while (rows.length > 0 && rows[rows.length - 1] === "") {
+      rows.pop()
+    }
+
+    return rows
+  }
+
+  pastedRowValue(row) {
+    const cells = row.split("\t").map((cell) => cell.trim()).filter(Boolean)
+    if (cells.length > 0) return this.normalizePastedCell(cells[cells.length - 1])
+
+    return this.normalizePastedCell(row)
+  }
+
+  normalizePastedCell(value) {
+    const trimmedValue = value.trim()
+    if (/^["'`]{3,}$/.test(trimmedValue)) return ""
+
+    return trimmedValue.replace(/^原曲\s*[:：]\s*/, "").trim()
+  }
+
+  missingQueryInputFor(element) {
+    const container = element.closest(".admin-original-song-missing-query")
+    return container?.querySelector(".admin-original-song-missing-input")
+  }
+
+  syncHiddenValue() {
+    this.hiddenTarget.value = this.selectedOptions.map((option) => option.value).join(",")
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,6 +9,7 @@ import AdminActionProgressController from "./admin_action_progress_controller"
 import AdminActionConfirmController from "./admin_action_confirm_controller"
 import AdminClickableRowController from "./admin_clickable_row_controller"
 import AdminInfiniteScrollController from "./admin_infinite_scroll_controller"
+import AdminOriginalSongPickerController from "./admin_original_song_picker_controller"
 import AdminThemeController from "./admin_theme_controller"
 import CountdownController from "./countdown_controller"
 import HelloController from "./hello_controller"
@@ -20,6 +21,7 @@ application.register("admin-action-progress", AdminActionProgressController)
 application.register("admin-action-confirm", AdminActionConfirmController)
 application.register("admin-clickable-row", AdminClickableRowController)
 application.register("admin-infinite-scroll", AdminInfiniteScrollController)
+application.register("admin-original-song-picker", AdminOriginalSongPickerController)
 application.register("admin-theme", AdminThemeController)
 application.register("countdown", CountdownController)
 application.register("hello", HelloController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -8,6 +8,7 @@ import AdminAssociationSelectController from "./admin_association_select_control
 import AdminActionProgressController from "./admin_action_progress_controller"
 import AdminActionConfirmController from "./admin_action_confirm_controller"
 import AdminClickableRowController from "./admin_clickable_row_controller"
+import AdminClipboardController from "./admin_clipboard_controller"
 import AdminInfiniteScrollController from "./admin_infinite_scroll_controller"
 import AdminOriginalSongPickerController from "./admin_original_song_picker_controller"
 import AdminThemeController from "./admin_theme_controller"
@@ -20,6 +21,7 @@ application.register("admin-association-select", AdminAssociationSelectControlle
 application.register("admin-action-progress", AdminActionProgressController)
 application.register("admin-action-confirm", AdminActionConfirmController)
 application.register("admin-clickable-row", AdminClickableRowController)
+application.register("admin-clipboard", AdminClipboardController)
 application.register("admin-infinite-scroll", AdminInfiniteScrollController)
 application.register("admin-original-song-picker", AdminOriginalSongPickerController)
 application.register("admin-theme", AdminThemeController)

--- a/app/views/admin/original_song_assignments/index.html.erb
+++ b/app/views/admin/original_song_assignments/index.html.erb
@@ -1,0 +1,142 @@
+<div class="admin-page-header">
+  <div class="admin-page-title">
+    <span class="admin-kicker"><%= t('admin.resources.tracks.label') %></span>
+    <h1><%= t('admin.original_song_assignments.title') %></h1>
+    <p><%= t('admin.original_song_assignments.description') %></p>
+  </div>
+  <div class="admin-page-actions">
+    <%= link_to admin_resources_path('tracks'), class: 'btn admin-btn' do %>
+      <%= admin_icon(:arrow_left) %>
+      <span><%= t('admin.actions.back_to_index') %></span>
+    <% end %>
+  </div>
+</div>
+
+<%= form_with url: admin_track_original_song_assignments_path,
+              method: :get,
+              class: 'admin-search-form admin-original-song-assignment-search-form' do |form| %>
+  <div class="admin-list-toolbar">
+    <div class="admin-filter-bar">
+      <div class="admin-filter-field">
+        <%= form.label :status, t('admin.original_song_assignments.status_label'), class: 'admin-label' %>
+        <%= form.select :status,
+                        options_for_select([
+                          [t('admin.original_song_assignments.status.missing'), 'missing'],
+                          [t('admin.original_song_assignments.status.present'), 'present'],
+                          [t('admin.original_song_assignments.status.all'), 'all']
+                        ], @status),
+                        {},
+                        class: 'select admin-select',
+                        onchange: 'this.form.requestSubmit()' %>
+      </div>
+      <label class="admin-checkbox-row">
+        <%= check_box_tag :show_identifiers, '1', @show_identifiers, onchange: 'this.form.requestSubmit()' %>
+        <span><%= t('admin.original_song_assignments.show_identifiers') %></span>
+      </label>
+    </div>
+
+    <div class="admin-list-controls">
+      <div class="admin-search-row">
+        <div class="admin-search-input">
+          <%= admin_icon(:search) %>
+          <%= form.search_field :q, value: @query, placeholder: t('admin.search.placeholder'), class: 'input admin-input' %>
+        </div>
+        <div class="admin-search-actions">
+          <%= form.button type: :submit, class: 'btn admin-btn-primary' do %>
+            <%= admin_icon(:search) %>
+            <span><%= t('admin.search.submit') %></span>
+          <% end %>
+          <% if @query.present? || @status != 'missing' || @show_identifiers %>
+            <%= link_to admin_track_original_song_assignments_path, class: 'btn admin-btn' do %>
+              <%= admin_icon(:x) %>
+              <span><%= t('admin.search.clear') %></span>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+      <div class="admin-record-count">
+        <span><%= t('admin.table.current_results') %></span>
+        <strong><%= admin_records_summary(@pagy) %></strong>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= form_with url: admin_track_original_song_assignments_path(q: @query, status: @status, show_identifiers: (@show_identifiers ? '1' : nil)),
+              method: :patch,
+              class: 'admin-original-song-assignment-form' do %>
+  <div class="admin-panel admin-table-panel admin-original-song-assignment-panel">
+    <div class="admin-panel-header">
+      <h2><%= t('admin.original_song_assignments.table_heading') %></h2>
+      <%= button_tag type: :submit, class: 'btn admin-btn-primary' do %>
+        <%= admin_icon(:check) %>
+        <span><%= t('admin.original_song_assignments.save') %></span>
+      <% end %>
+    </div>
+    <div class="admin-table-scroll">
+      <table class="table admin-table admin-original-song-assignment-table">
+        <thead>
+          <tr>
+            <th><%= t('admin.attributes.common.circle_name') %></th>
+            <th><%= t('admin.attributes.common.album_name') %></th>
+            <th><%= t('admin.attributes.common.name') %></th>
+            <% if @show_identifiers %>
+              <th><%= t('admin.attributes.common.jan_code') %></th>
+              <th><%= t('admin.attributes.common.isrc') %></th>
+            <% end %>
+            <th><%= t('admin.original_song_assignments.original_songs') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @tracks.each do |track| %>
+            <% selected_original_songs = track.original_songs.sort_by { |song| [song.original_code, song.track_number, song.code] } %>
+            <% selected_options = selected_original_songs.map { |song| { value: song.code, label: [song.code, song.title, song.original_title].compact_blank.uniq.join(' / ') } } %>
+            <tr>
+              <td><%= admin_display_value(@track_resource, track, :circle_name) %></td>
+              <td><%= admin_display_value(@track_resource, track, :album_name) %></td>
+              <td><%= admin_display_value(@track_resource, track, :name) %></td>
+              <% if @show_identifiers %>
+                <td><%= track.jan_code %></td>
+                <td><%= track.isrc %></td>
+              <% end %>
+              <td class="admin-original-song-picker-cell">
+                <div class="admin-original-song-picker"
+                     data-controller="admin-original-song-picker"
+                     data-admin-original-song-picker-url-value="<%= admin_track_original_song_assignment_options_path %>"
+                     data-admin-original-song-picker-resolve-url-value="<%= admin_resolve_track_original_song_assignments_path %>"
+                     data-admin-original-song-picker-initial-options-value="<%= json_escape(selected_options.to_json) %>">
+                  <%= hidden_field_tag "assignments[#{track.id}][original_song_codes]",
+                                       selected_original_songs.map(&:code).join(','),
+                                       data: { admin_original_song_picker_target: 'hidden' } %>
+                  <div class="admin-original-song-selected" data-admin-original-song-picker-target="selected"></div>
+                  <div class="admin-original-song-search">
+                    <%= admin_icon(:search) %>
+                    <input type="search"
+                           class="input admin-input admin-original-song-search-input"
+                           placeholder="<%= t('admin.original_song_assignments.search_placeholder') %>"
+                           autocomplete="off"
+                           role="combobox"
+                           aria-expanded="false"
+                           data-admin-original-song-picker-target="input"
+                           data-action="focus->admin-original-song-picker#focus input->admin-original-song-picker#filter keydown->admin-original-song-picker#keydown paste->admin-original-song-picker#paste blur->admin-original-song-picker#blur">
+                    <div class="admin-original-song-listbox"
+                         role="listbox"
+                         hidden
+                         data-admin-original-song-picker-target="listbox"></div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+          <% if @tracks.empty? %>
+            <tr>
+              <td colspan="<%= @show_identifiers ? 6 : 4 %>" class="admin-table-empty"><%= t('admin.original_song_assignments.empty') %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>
+
+<%= admin_pagination(@pagy) %>

--- a/app/views/admin/original_song_missing_albums/index.html.erb
+++ b/app/views/admin/original_song_missing_albums/index.html.erb
@@ -1,0 +1,103 @@
+<div class="admin-page-header">
+  <div class="admin-page-title">
+    <span class="admin-kicker"><%= t('admin.resources.albums.label') %></span>
+    <h1><%= t('admin.original_song_missing_albums.title') %></h1>
+    <p><%= t('admin.original_song_missing_albums.description') %></p>
+  </div>
+  <div class="admin-page-actions">
+    <%= link_to admin_resources_path('albums'), class: 'btn admin-btn' do %>
+      <%= admin_icon(:arrow_left) %>
+      <span><%= t('admin.actions.back_to_index') %></span>
+    <% end %>
+    <%= link_to admin_track_original_song_assignments_path, class: 'btn admin-btn' do %>
+      <%= admin_icon(:list_ordered) %>
+      <span><%= t('admin.original_song_assignments.nav_label') %></span>
+    <% end %>
+  </div>
+</div>
+
+<%= form_with url: admin_original_song_missing_albums_path, method: :get, class: 'admin-search-form admin-original-song-missing-albums-search-form' do |form| %>
+  <div class="admin-list-toolbar">
+    <div class="admin-list-controls">
+      <div class="admin-search-row">
+        <div class="admin-search-input">
+          <%= admin_icon(:search) %>
+          <%= form.search_field :q, value: @query, placeholder: t('admin.search.placeholder'), class: 'input admin-input' %>
+        </div>
+        <div class="admin-search-actions">
+          <%= form.button type: :submit, class: 'btn admin-btn-primary' do %>
+            <%= admin_icon(:search) %>
+            <span><%= t('admin.search.submit') %></span>
+          <% end %>
+          <% if @query.present? %>
+            <%= link_to admin_original_song_missing_albums_path, class: 'btn admin-btn' do %>
+              <%= admin_icon(:x) %>
+              <span><%= t('admin.search.clear') %></span>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+      <div class="admin-record-count">
+        <span><%= t('admin.table.current_results') %></span>
+        <strong><%= admin_records_summary(@pagy) %></strong>
+      </div>
+      <div class="admin-original-song-missing-albums-copy"
+           data-controller="admin-clipboard">
+        <textarea class="visually-hidden" data-admin-clipboard-target="source"><%= @copy_text %></textarea>
+        <%= button_tag type: :button,
+                       class: 'btn admin-btn',
+                       disabled: @copy_text.blank?,
+                       data: { action: 'admin-clipboard#copy' } do %>
+          <%= admin_icon(:copy) %>
+          <span><%= t('admin.original_song_missing_albums.copy') %></span>
+        <% end %>
+        <span class="admin-copy-status" data-admin-clipboard-target="status" aria-live="polite"></span>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="admin-panel admin-table-panel admin-original-song-missing-albums-panel">
+  <div class="admin-table-scroll">
+    <table class="table admin-table admin-original-song-missing-albums-table">
+      <thead>
+        <tr>
+          <th><%= t('admin.attributes.common.circle_name') %></th>
+          <th><%= t('admin.original_song_missing_albums.album') %></th>
+          <th><%= t('admin.attributes.common.jan_code') %></th>
+          <th><%= t('admin.original_song_missing_albums.missing_tracks_count') %></th>
+          <th class="admin-table-actions-heading"><%= t('admin.table.actions') %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @albums.each do |album| %>
+          <tr>
+            <td><%= album.circle_name.presence || tag.span(t('admin.shared.blank'), class: 'admin-muted-text') %></td>
+            <td><%= album_name(album) %></td>
+            <td><%= album.jan_code %></td>
+            <td><%= @missing_track_counts.fetch(album.jan_code, 0) %></td>
+            <td class="admin-table-actions-cell">
+              <div class="admin-row-actions">
+                <%= link_to admin_track_original_song_assignments_path(q: album.jan_code), class: 'btn btn-sm admin-btn' do %>
+                  <%= admin_icon(:list_ordered) %>
+                  <span><%= t('admin.original_song_missing_albums.assign') %></span>
+                <% end %>
+                <%= link_to admin_resource_path('albums', album), class: 'btn btn-sm admin-btn', title: t('admin.actions.show') do %>
+                  <%= admin_icon(:eye) %>
+                  <span class="visually-hidden"><%= t('admin.actions.show') %></span>
+                <% end %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+        <% if @albums.empty? %>
+          <tr>
+            <td colspan="5" class="admin-table-empty"><%= t('admin.original_song_missing_albums.empty') %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<%= admin_pagination(@pagy) %>

--- a/app/views/admin/resources/index.html.erb
+++ b/app/views/admin/resources/index.html.erb
@@ -22,6 +22,12 @@
         <span><%= t('admin.original_song_assignments.nav_label') %></span>
       <% end %>
     <% end %>
+    <% if @resource_config.key == 'albums' %>
+      <%= link_to admin_original_song_missing_albums_path, class: 'btn btn-sm admin-btn' do %>
+        <%= admin_icon(:list_ordered) %>
+        <span><%= t('admin.original_song_missing_albums.nav_label') %></span>
+      <% end %>
+    <% end %>
     <%= link_to admin_new_resource_path(@resource_config.key), class: 'btn admin-btn-primary' do %>
       <%= admin_icon(:plus) %>
       <span class="admin-resource-index-new-label"><%= t('admin.actions.new_record') %></span>

--- a/app/views/admin/resources/index.html.erb
+++ b/app/views/admin/resources/index.html.erb
@@ -16,6 +16,12 @@
         <span><%= action.label %></span>
       <% end %>
     <% end %>
+    <% if @resource_config.key == 'tracks' %>
+      <%= link_to admin_track_original_song_assignments_path, class: 'btn btn-sm admin-btn' do %>
+        <%= admin_icon(:list_ordered) %>
+        <span><%= t('admin.original_song_assignments.nav_label') %></span>
+      <% end %>
+    <% end %>
     <%= link_to admin_new_resource_path(@resource_config.key), class: 'btn admin-btn-primary' do %>
       <%= admin_icon(:plus) %>
       <span class="admin-resource-index-new-label"><%= t('admin.actions.new_record') %></span>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -145,6 +145,15 @@ en:
       no_assignments: "There are no assignments to update."
       track_not_found: "Track was not found: %{id}"
       original_songs_not_found: "%{isrc}: Original songs were not found: %{codes}"
+    original_song_missing_albums:
+      title: "Albums Needing Original Song Assignments"
+      nav_label: "Albums missing original songs"
+      description: "Review albums that include tracks without original songs. Copy outputs tab-separated circle and album names."
+      album: "Album"
+      missing_tracks_count: "Missing tracks"
+      copy: "Copy circle/album"
+      assign: "Assign"
+      empty: "No albums need original song assignments."
     relations:
       heading: "Relations"
       empty: "No related records."

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -126,6 +126,25 @@ en:
       association_change_placeholder: "Search to change"
     confirm:
       destroy: "Delete this record?"
+    original_song_assignments:
+      title: "Track Original Song Assignments"
+      nav_label: "Assign original songs"
+      description: "Assign multiple original songs while reviewing tracks in a table. Tracks missing original songs are shown by default."
+      table_heading: "Tracks to assign"
+      status_label: "Target"
+      status:
+        missing: "Missing original songs"
+        present: "Has original songs"
+        all: "All"
+      original_songs: "Original songs"
+      show_identifiers: "Show JAN/ISRC"
+      search_placeholder: "Search by code, song, or original work"
+      save: "Save"
+      empty: "No tracks found."
+      update_success: "Original song assignments were updated."
+      no_assignments: "There are no assignments to update."
+      track_not_found: "Track was not found: %{id}"
+      original_songs_not_found: "%{isrc}: Original songs were not found: %{codes}"
     relations:
       heading: "Relations"
       empty: "No related records."

--- a/config/locales/admin.ja.yml
+++ b/config/locales/admin.ja.yml
@@ -161,6 +161,25 @@ ja:
       association_change_placeholder: "変更する場合は検索"
     confirm:
       destroy: "削除しますか？"
+    original_song_assignments:
+      title: "楽曲の原曲紐づけ"
+      nav_label: "原曲を表で紐づけ"
+      description: "楽曲を一覧しながら、原曲を検索して複数紐づけできます。初期表示は原曲未設定の楽曲です。"
+      table_heading: "紐づけ対象楽曲"
+      status_label: "対象"
+      status:
+        missing: "原曲未設定"
+        present: "原曲設定済み"
+        all: "すべて"
+      original_songs: "原曲"
+      show_identifiers: "JAN/ISRCを表示"
+      search_placeholder: "原曲コード・曲名・原作で検索"
+      save: "保存"
+      empty: "対象の楽曲はありません。"
+      update_success: "原曲の紐づけを更新しました。"
+      no_assignments: "更新対象がありません。"
+      track_not_found: "楽曲が見つかりません: %{id}"
+      original_songs_not_found: "%{isrc}: 原曲が見つかりません: %{codes}"
     relations:
       heading: "関連"
       empty: "関連レコードはありません。"

--- a/config/locales/admin.ja.yml
+++ b/config/locales/admin.ja.yml
@@ -180,6 +180,15 @@ ja:
       no_assignments: "更新対象がありません。"
       track_not_found: "楽曲が見つかりません: %{id}"
       original_songs_not_found: "%{isrc}: 原曲が見つかりません: %{codes}"
+    original_song_missing_albums:
+      title: "原曲紐づけが必要なアルバム"
+      nav_label: "原曲未設定アルバム"
+      description: "原曲が未設定の楽曲を含むアルバムを一覧できます。コピーすると、サークルとアルバム名をタブ区切りで取得できます。"
+      album: "アルバム"
+      missing_tracks_count: "未設定楽曲数"
+      copy: "サークル/アルバムをコピー"
+      assign: "紐づけ"
+      empty: "原曲紐づけが必要なアルバムはありません。"
     relations:
       heading: "関連"
       empty: "関連レコードはありません。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: 'dashboard#show'
+    get 'original_song_missing_albums', to: 'original_song_missing_albums#index', as: :original_song_missing_albums
     get 'track_original_song_assignments', to: 'original_song_assignments#index', as: :track_original_song_assignments
     patch 'track_original_song_assignments', to: 'original_song_assignments#update'
     get 'track_original_song_assignments/options', to: 'original_song_assignments#options', as: :track_original_song_assignment_options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,11 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: 'dashboard#show'
+    get 'track_original_song_assignments', to: 'original_song_assignments#index', as: :track_original_song_assignments
+    patch 'track_original_song_assignments', to: 'original_song_assignments#update'
+    get 'track_original_song_assignments/options', to: 'original_song_assignments#options', as: :track_original_song_assignment_options
+    get 'track_original_song_assignments/resolve', to: 'original_song_assignments#resolve', as: :resolve_track_original_song_assignments
+
     constraints resource: Admin::Resource.route_constraint do
       get ':resource', to: 'resources#index', as: :resources
       post ':resource', to: 'resources#create'

--- a/test/controllers/admin/original_song_assignments_controller_test.rb
+++ b/test/controllers/admin/original_song_assignments_controller_test.rb
@@ -127,6 +127,39 @@ module Admin
       assert_equal [[first_song.code], [second_song.code], [third_song.code]], resolution_option_values
     end
 
+    test 'does not split a pasted original song title that contains common delimiters' do
+      comma_song = create_original_song(code: 'ASSIGN-PASTE-DELIMITER-001', title: 'Paste、Delimiter Song')
+      slash_song = create_original_song(code: 'ASSIGN-PASTE-DELIMITER-002', title: 'Paste／Delimiter Song')
+      ascii_comma_song = create_original_song(code: 'ASSIGN-PASTE-DELIMITER-003', title: 'Paste, Delimiter Song')
+
+      get admin_resolve_track_original_song_assignments_url,
+          params: { text: "#{comma_song.title}\n#{slash_song.title}\n#{ascii_comma_song.title}" }
+
+      assert_response :success
+      resolutions = response.parsed_body.fetch('resolutions')
+      resolution_queries = resolutions.map { |resolution| resolution.fetch('query') }
+      resolution_option_values = resolutions.map { |resolution| resolution.fetch('options').pluck('value') }
+      assert_equal [comma_song.title, slash_song.title, ascii_comma_song.title], resolution_queries
+      assert_equal [[comma_song.code], [slash_song.code], [ascii_comma_song.code]], resolution_option_values
+    end
+
+    test 'splits pasted songs while preserving delimiters inside known titles' do
+      comma_song = create_original_song(code: 'ASSIGN-PASTE-MIXED-001', title: 'Paste、Known Song')
+      slash_song = create_original_song(code: 'ASSIGN-PASTE-MIXED-002', title: 'Paste／Known Song')
+      ascii_comma_song = create_original_song(code: 'ASSIGN-PASTE-MIXED-003', title: 'Paste, Known Song')
+      plain_song = create_original_song(code: 'ASSIGN-PASTE-MIXED-004', title: 'Paste Plain Song')
+
+      get admin_resolve_track_original_song_assignments_url,
+          params: { text: "#{comma_song.title}、#{slash_song.title}／#{ascii_comma_song.title},#{plain_song.title}" }
+
+      assert_response :success
+      resolutions = response.parsed_body.fetch('resolutions')
+      resolution_queries = resolutions.map { |resolution| resolution.fetch('query') }
+      resolution_option_values = resolutions.map { |resolution| resolution.fetch('options').pluck('value') }
+      assert_equal [comma_song.title, slash_song.title, ascii_comma_song.title, plain_song.title], resolution_queries
+      assert_equal [[comma_song.code], [slash_song.code], [ascii_comma_song.code], [plain_song.code]], resolution_option_values
+    end
+
     test 'returns multiple choices for ambiguous pasted original song titles' do
       first_song = create_original_song(code: 'ASSIGN-AMBIGUOUS-001', title: 'Ambiguous Paste Song')
       second_song = create_original_song(code: 'ASSIGN-AMBIGUOUS-002', title: 'Ambiguous Paste Song')

--- a/test/controllers/admin/original_song_assignments_controller_test.rb
+++ b/test/controllers/admin/original_song_assignments_controller_test.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class OriginalSongAssignmentsControllerTest < ActionDispatch::IntegrationTest
+    test 'shows tracks missing original songs by default' do
+      missing_track = create_track(jan_code: '9777777779101', isrc: 'JPABC269101')
+      linked_track = create_track(jan_code: '9777777779102', isrc: 'JPABC269102')
+      linked_track.original_songs << create_original_song(code: 'ASSIGN-DEFAULT-001', title: 'Assigned Default Song')
+
+      get admin_track_original_song_assignments_url
+
+      assert_response :success
+      assert_select 'h1', '楽曲の原曲紐づけ'
+      assert_select 'select[name=?] option[selected]', 'status', text: '原曲未設定'
+      assert_select 'input[name=?][type=?]', 'show_identifiers', 'checkbox', count: 1
+      assert_select 'th', { text: 'JANコード', count: 0 }
+      assert_select 'th', { text: 'ISRC', count: 0 }
+      assert_select 'td', { text: missing_track.isrc, count: 0 }
+      assert_select 'form[method=?]', 'post'
+      assert_select 'input[name=?]', "assignments[#{missing_track.id}][original_song_codes]"
+      assert_select 'input[name=?]', "assignments[#{linked_track.id}][original_song_codes]", count: 0
+    end
+
+    test 'can show tracks that already have original songs' do
+      missing_track = create_track(jan_code: '9777777779111', isrc: 'JPABC269111')
+      linked_track = create_track(jan_code: '9777777779112', isrc: 'JPABC269112')
+      linked_track.original_songs << create_original_song(code: 'ASSIGN-PRESENT-001', title: 'Assigned Present Song')
+
+      get admin_track_original_song_assignments_url, params: { status: 'present' }
+
+      assert_response :success
+      assert_select 'input[name=?]', "assignments[#{linked_track.id}][original_song_codes]"
+      assert_select 'input[name=?]', "assignments[#{missing_track.id}][original_song_codes]", count: 0
+    end
+
+    test 'can show track identifiers when requested' do
+      track = create_track(jan_code: '9777777779113', isrc: 'JPABC269113')
+
+      get admin_track_original_song_assignments_url, params: { show_identifiers: '1' }
+
+      assert_response :success
+      assert_select 'input[name=?][type=?][checked=?]', 'show_identifiers', 'checkbox', 'checked'
+      assert_select 'th', text: 'JANコード'
+      assert_select 'th', text: 'ISRC'
+      assert_select 'td', text: track.jan_code
+      assert_select 'td', text: track.isrc
+    end
+
+    test 'orders tracks by streaming track number within the same album' do
+      album = Album.create!(jan_code: '9777777779115')
+      spotify_album = create_spotify_album(album:, spotify_id: 'assign-order-album')
+      second_track = Track.create!(album:, isrc: 'JPABC2691152')
+      first_track = Track.create!(album:, isrc: 'JPABC2691151')
+      create_spotify_track(album:, track: second_track, spotify_album:, spotify_id: 'assign-order-track-2', track_number: 2)
+      create_spotify_track(album:, track: first_track, spotify_album:, spotify_id: 'assign-order-track-1', track_number: 1)
+
+      get admin_track_original_song_assignments_url, params: { q: album.jan_code }
+
+      assert_response :success
+      assert_operator response.body.index('assign-order-track-1'), :<, response.body.index('assign-order-track-2')
+    end
+
+    test 'updates original song assignments with multiple selected songs' do
+      track = create_track(jan_code: '9777777779121', isrc: 'JPABC269121')
+      first_song = create_original_song(code: 'ASSIGN-UPDATE-001', title: 'Assigned Update First', track_number: 1)
+      second_song = create_original_song(code: 'ASSIGN-UPDATE-002', title: 'Assigned Update Second', track_number: 2)
+
+      patch admin_track_original_song_assignments_url,
+            params: {
+              assignments: {
+                track.id => {
+                  original_song_codes: "#{first_song.code},#{second_song.code}"
+                }
+              }
+            }
+
+      assert_redirected_to admin_track_original_song_assignments_path
+      assert_equal [first_song.code, second_song.code], track.reload.original_songs.order(:track_number).pluck(:code)
+    end
+
+    test 'does not persist partial updates when an original song code is invalid' do
+      valid_track = create_track(jan_code: '9777777779131', isrc: 'JPABC269131')
+      invalid_track = create_track(jan_code: '9777777779132', isrc: 'JPABC269132')
+      song = create_original_song(code: 'ASSIGN-ROLLBACK-001', title: 'Assigned Rollback Song')
+
+      patch admin_track_original_song_assignments_url,
+            params: {
+              assignments: {
+                valid_track.id => { original_song_codes: song.code },
+                invalid_track.id => { original_song_codes: 'ASSIGN-MISSING-999' }
+              }
+            }
+
+      assert_redirected_to admin_track_original_song_assignments_path
+      assert_empty valid_track.reload.original_songs
+      assert_empty invalid_track.reload.original_songs
+    end
+
+    test 'searches original song options' do
+      create_original_song(code: 'ASSIGN-OPTION-001', title: 'Needle Mountain')
+      create_original_song(code: 'ASSIGN-OPTION-002', title: 'Unrelated Song')
+
+      get admin_track_original_song_assignment_options_url, params: { q: 'Needle' }
+
+      assert_response :success
+      options = response.parsed_body.fetch('options')
+      option_values = options.map { |option| option.fetch('value') }
+      assert_equal ['ASSIGN-OPTION-001'], option_values
+      assert_match(/Needle Mountain/, options.first.fetch('label'))
+    end
+
+    test 'resolves pasted original song titles split by common delimiters' do
+      first_song = create_original_song(code: 'ASSIGN-PASTE-001', title: 'Paste First')
+      second_song = create_original_song(code: 'ASSIGN-PASTE-002', title: 'Paste Second')
+      third_song = create_original_song(code: 'ASSIGN-PASTE-003', title: 'Paste Third')
+
+      get admin_resolve_track_original_song_assignments_url,
+          params: { text: "#{first_song.title} / #{second_song.title}、#{third_song.code}" }
+
+      assert_response :success
+      resolutions = response.parsed_body.fetch('resolutions')
+      resolution_queries = resolutions.map { |resolution| resolution.fetch('query') }
+      resolution_option_values = resolutions.map { |resolution| resolution.fetch('options').pluck('value') }
+      assert_equal ['Paste First', 'Paste Second', 'ASSIGN-PASTE-003'], resolution_queries
+      assert_equal [[first_song.code], [second_song.code], [third_song.code]], resolution_option_values
+    end
+
+    test 'returns multiple choices for ambiguous pasted original song titles' do
+      first_song = create_original_song(code: 'ASSIGN-AMBIGUOUS-001', title: 'Ambiguous Paste Song')
+      second_song = create_original_song(code: 'ASSIGN-AMBIGUOUS-002', title: 'Ambiguous Paste Song')
+
+      get admin_resolve_track_original_song_assignments_url,
+          params: { text: 'Ambiguous Paste Song' }
+
+      assert_response :success
+      options = response.parsed_body.fetch('resolutions').first.fetch('options')
+      option_values = options.map { |option| option.fetch('value') }
+      assert_equal [first_song.code, second_song.code], option_values
+    end
+
+    test 'resolves pasted titles with normalized spaces' do
+      song = create_original_song(code: 'ASSIGN-SPACE-001', title: 'Space　Normalized Song')
+
+      get admin_resolve_track_original_song_assignments_url,
+          params: { text: 'Space Normalized Song' }
+
+      assert_response :success
+      options = response.parsed_body.fetch('resolutions').first.fetch('options')
+      option_values = options.map { |option| option.fetch('value') }
+      assert_equal [song.code], option_values
+    end
+
+    test 'resolves pasted titles with compact tilde spacing' do
+      song = create_original_song(code: 'ASSIGN-TILDE-001', title: '最後の一人は慣れてるから　～ Stone Goddess')
+
+      get admin_resolve_track_original_song_assignments_url,
+          params: { text: '最後の一人は慣れてるから ～Stone Goddess' }
+
+      assert_response :success
+      options = response.parsed_body.fetch('resolutions').first.fetch('options')
+      option_values = options.map { |option| option.fetch('value') }
+      assert_equal [song.code], option_values
+    end
+
+    test 'resolves pasted titles with normalized question marks' do
+      song = create_original_song(code: 'ASSIGN-QUESTION-001', title: 'U.N.オーエンは彼女なのか？')
+
+      get admin_resolve_track_original_song_assignments_url,
+          params: { text: 'U.N.オーエンは彼女なのか?' }
+
+      assert_response :success
+      options = response.parsed_body.fetch('resolutions').first.fetch('options')
+      option_values = options.map { |option| option.fetch('value') }
+      assert_equal [song.code], option_values
+    end
+
+    test 'resolves pasted titles with original song labels and wrapper quotes' do
+      first_song = create_original_song(code: 'ASSIGN-LABEL-001', title: '妖魔夜行')
+      second_song = create_original_song(code: 'ASSIGN-LABEL-002', title: 'U.N.オーエンは彼女なのか？')
+
+      get admin_resolve_track_original_song_assignments_url,
+          params: {
+            text: <<~TEXT
+              """
+              原曲: 妖魔夜行
+              原曲： U.N.オーエンは彼女なのか?
+              """
+            TEXT
+          }
+
+      assert_response :success
+      resolutions = response.parsed_body.fetch('resolutions')
+      resolution_queries = resolutions.map { |resolution| resolution.fetch('query') }
+      resolution_option_values = resolutions.map { |resolution| resolution.fetch('options').pluck('value') }
+      assert_equal ['妖魔夜行', 'U.N.オーエンは彼女なのか?'], resolution_queries
+      assert_equal [[first_song.code], [second_song.code]], resolution_option_values
+    end
+
+    private
+
+    def create_track(jan_code:, isrc:)
+      album = Album.create!(jan_code:)
+      Track.create!(album:, isrc:)
+    end
+
+    def create_spotify_album(album:, spotify_id:)
+      SpotifyAlbum.create!(
+        album:,
+        spotify_id:,
+        album_type: 'album',
+        name: spotify_id,
+        label: Album::TOUHOU_MUSIC_LABEL,
+        active: true,
+        payload: { 'available_markets' => ['JP'] }
+      )
+    end
+
+    def create_spotify_track(album:, track:, spotify_album:, spotify_id:, track_number:)
+      SpotifyTrack.create!(
+        album:,
+        track:,
+        spotify_album:,
+        spotify_id:,
+        name: spotify_id,
+        label: Album::TOUHOU_MUSIC_LABEL,
+        disc_number: 1,
+        track_number:,
+        duration_ms: 180_000,
+        payload: {}
+      )
+    end
+
+    def create_original_song(code:, title:, track_number: 1)
+      original = Original.find_or_create_by!(code: "#{code}-ORIGINAL") do |record|
+        record.title = "#{title} Original"
+        record.short_title = "#{title} Original"
+        record.original_type = 'other'
+        record.series_order = 900.0
+      end
+
+      OriginalSong.create!(
+        code:,
+        original:,
+        title:,
+        composer: 'ZUN',
+        track_number:
+      )
+    end
+  end
+end

--- a/test/controllers/admin/original_song_missing_albums_controller_test.rb
+++ b/test/controllers/admin/original_song_missing_albums_controller_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class OriginalSongMissingAlbumsControllerTest < ActionDispatch::IntegrationTest
+    test 'lists albums that include tracks missing original songs' do
+      missing_album = create_album(jan_code: '9777777780101', circle_name: 'Missing Circle', album_name: 'Missing Album')
+      missing_track = create_track(album: missing_album, isrc: 'JPABC2780101')
+      create_track(album: missing_album, isrc: 'JPABC2780102')
+
+      linked_album = create_album(jan_code: '9777777780102', circle_name: 'Linked Circle', album_name: 'Linked Album')
+      linked_track = create_track(album: linked_album, isrc: 'JPABC2780103')
+      linked_track.original_songs << create_original_song(code: 'MISSING-ALBUM-LINKED-001', title: 'Linked Original Song')
+
+      get admin_original_song_missing_albums_url
+
+      assert_response :success
+      assert_select 'h1', '原曲紐づけが必要なアルバム'
+      assert_select 'td', text: 'Missing Circle'
+      assert_select 'td', text: 'Missing Album'
+      assert_select 'td', text: '2'
+      assert_select 'td', { text: 'Linked Album', count: 0 }
+      assert_select 'a[href=?]', admin_track_original_song_assignments_path(q: missing_album.jan_code), text: '紐づけ'
+      assert_select 'textarea[data-admin-clipboard-target=?]', 'source', text: "Missing Circle\tMissing Album"
+      assert_not_includes response.body, missing_track.isrc
+    end
+
+    test 'filters missing albums and copies matching circle and album columns' do
+      matching_album = create_album(jan_code: '9777777780111', circle_name: 'Filter Circle', album_name: 'Filter Album')
+      other_album = create_album(jan_code: '9777777780112', circle_name: 'Other Circle', album_name: 'Other Album')
+      create_track(album: matching_album, isrc: 'JPABC2780111')
+      create_track(album: other_album, isrc: 'JPABC2780112')
+
+      get admin_original_song_missing_albums_url, params: { q: 'Filter' }
+
+      assert_response :success
+      assert_select 'td', text: 'Filter Album'
+      assert_select 'td', { text: 'Other Album', count: 0 }
+      assert_select 'textarea[data-admin-clipboard-target=?]', 'source', text: "Filter Circle\tFilter Album"
+    end
+
+    private
+
+    def create_album(jan_code:, circle_name:, album_name:)
+      album = Album.create!(jan_code:)
+      album.circles << Circle.create!(name: circle_name)
+      SpotifyAlbum.create!(
+        album:,
+        spotify_id: "#{jan_code}-spotify",
+        album_type: 'album',
+        name: album_name,
+        label: Album::TOUHOU_MUSIC_LABEL,
+        active: true,
+        payload: { 'available_markets' => ['JP'] }
+      )
+      album
+    end
+
+    def create_track(album:, isrc:)
+      Track.create!(album:, isrc:)
+    end
+
+    def create_original_song(code:, title:)
+      original = Original.find_or_create_by!(code: "#{code}-ORIGINAL") do |record|
+        record.title = "#{title} Original"
+        record.short_title = "#{title} Original"
+        record.original_type = 'other'
+        record.series_order = 900.0
+      end
+
+      OriginalSong.create!(
+        code:,
+        original:,
+        title:,
+        composer: 'ZUN',
+        track_number: 1
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 概要

楽曲の原曲紐づけ作業を管理画面から効率よく行えるようにしました。

- 原曲未設定の楽曲を表形式で一覧し、各行で原曲を複数選択できる画面を追加
- Excel やスプレッドシートから複数行を貼り付けて、表示中の楽曲へ行単位で割り当てられるように対応
- `原曲: 妖魔夜行` のようなラベル付きテキスト、カンマ・スラッシュ区切り、表記ゆれを吸収して候補解決
- `、` / `／` / `,` が原曲名に含まれる場合は、既知の原曲名として成立する部分を優先して誤分割しないように対応
- 原曲未設定の楽曲を含むアルバム一覧を追加し、`サークル<TAB>アルバム` 形式でコピーできるように対応

## 仕組み

### 全体像

```mermaid
flowchart LR
  A["管理画面: 原曲紐づけ表"] --> B["Admin::OriginalSongAssignmentsController"]
  B --> C["Track.missing_original_songs"]
  B --> D["/options: 原曲候補検索"]
  B --> E["/resolve: 貼り付け解決"]
  D --> F["OriginalSong.non_duplicated"]
  E --> F
  A --> G["Track.original_songs を更新"]

  H["管理画面: 原曲未設定アルバム一覧"] --> I["Admin::OriginalSongMissingAlbumsController"]
  I --> J["Album.tracks_missing_original_songs"]
  H --> K["サークル + アルバムをTSVコピー"]
```

### 楽曲ごとの原曲紐づけ

`Admin::OriginalSongAssignmentsController` を追加し、原曲紐づけ専用の管理画面を用意しています。初期表示では `Track.missing_original_songs` を対象にし、必要に応じて原曲設定済み・全件へ切り替えられます。

楽曲の並び順は Track 自体にトラック番号がないため、配信サービス側のトラック番号を参照しています。active Spotify、Apple Music、LINE MUSIC、YouTube Music、Spotify fallback の順に番号を探し、同一アルバム内ではその番号順に並べています。

```mermaid
flowchart TD
  A["Track一覧の取得"] --> B{"status"}
  B -->|missing| C["Track.missing_original_songs"]
  B -->|present| D["original_songs 紐づけ済み"]
  B -->|all| E["全Track"]
  C --> F["検索条件 q を適用"]
  D --> F
  E --> F
  F --> G["配信サービスのdisc/track番号で並び替え"]
  G --> H["表形式で表示"]
```

### 原曲候補の検索と貼り付け解決

フロント側は `admin-original-song-picker` Stimulus controller で、各行の原曲選択 UI を管理しています。

通常入力時は `/admin/track_original_song_assignments/options` で候補を取得します。貼り付け時は `/admin/track_original_song_assignments/resolve` にテキストを送り、サーバ側で原曲候補へ解決します。

貼り付けテキストは以下を扱えるようにしています。

- 複数行貼り付け: 現在行から下方向へ1行ずつ割り当て
- 1行内の複数原曲: `,`、`、`、`/`、`／` などで分割
- ラベル付き行: `原曲:` / `原曲：` を除去
- 囲い行: `"""` などを無視
- 表記ゆれ: 全角/半角スペース、`～` 周辺スペース、`?` / `？`、`!` / `！` を吸収

区切り文字を含む原曲名への対応として、貼り付け行は最初に行全体を候補検索します。行全体で見つからない場合も、単純に左から分割するのではなく、分割片を区切り文字込みで再結合しながら「既知の原曲名として成立する最長部分」を優先して解決します。これにより、`幽雅に咲かせ、墨染の桜　～ Border of Life、妖魔夜行` のように原曲名内の `、` と複数原曲の区切りが混ざるケースでも、内部の `、` を壊さずに扱えます。

```mermaid
flowchart TD
  A["貼り付けテキスト"] --> B["行ごとに処理"]
  B --> C["原曲: などのラベルや囲い行を正規化"]
  C --> D{"行全体で候補が見つかる?"}
  D -->|Yes| E["1つの原曲クエリとして扱う"]
  D -->|No| F["カンマ/読点/スラッシュで一旦分割"]
  F --> G["分割片を区切り文字込みで再結合"]
  G --> H{"既知の原曲名として成立する最長部分がある?"}
  H -->|Yes| I["その部分を1つの原曲クエリとして採用"]
  H -->|No| J["単独の分割片として扱う"]
  I --> K["/resolve の候補リスト"]
  J --> K
  E --> K
  K --> L{"候補数"}
  L -->|1件| M["自動でチップ追加"]
  L -->|複数件| N["候補を選択表示"]
  L -->|0件| O["貼り付け文字列を編集して再検索"]
```

候補が1件に確定した場合は自動でチップ追加し、複数候補の場合は選択肢として表示します。候補が見つからない場合は、その場で貼り付け文字列を編集して再検索できます。

### アルバム単位の確認とコピー

`Admin::OriginalSongMissingAlbumsController` を追加し、`Album.tracks_missing_original_songs` を使って原曲未設定トラックを含むアルバムを一覧化しています。

一覧ではサークル、アルバム名、JAN、未設定楽曲数を表示し、各アルバムから原曲紐づけ画面へ遷移できます。コピー用には `admin-clipboard` Stimulus controller を追加し、検索条件に一致する全アルバムを `サークル<TAB>アルバム` の TSV 形式でクリップボードへ書き込むようにしています。

## 確認

- 実DBの `original_songs.title` に区切り文字を含むデータがあることを確認
  - `、`: 21件
  - `／`: 10件
  - `,`: 1件
- `devbox run bin/rails test test/controllers/admin/original_song_assignments_controller_test.rb`
- `devbox run bin/rails test`
- `make rubocop`
- `devbox run yarn build`
- Playwright で以下を確認
  - 複数行貼り付けで複数楽曲へ行単位に割り当てられること
  - `原曲:` ラベル付きテキストを貼り付けられること
  - 原曲未設定アルバム一覧とコピー元テキストが表示されること