### PR TITLE
Ruby 4.0でのCGI::Cookie削除に対応

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -197,7 +197,7 @@
     },
     "nodejs@20": {
       "last_modified": "2026-01-24T23:43:55Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/26b0093bc977081dc7653175a3fadab11e07bed7#nodejs_20",
       "source": "devbox-search",
       "version": "20.20.0",

--- a/lib/yt_music/client.rb
+++ b/lib/yt_music/client.rb
@@ -147,7 +147,24 @@ module YtMusic
       end
 
       def sapisid
-        @sapisid ||= CGI::Cookie.parse(ENV.fetch('YOUTUBE_MUSIC_COOKIE', nil))['SAPISID']&.first
+        @sapisid ||= parse_cookie_header(ENV.fetch('YOUTUBE_MUSIC_COOKIE', nil))['SAPISID']
+      end
+
+      # Ruby 4.0 で cgi/cookie が削除されたため、その parse 相当の処理を自前で行う。
+      # "NAME1=value1; NAME2=value2" 形式の Cookie ヘッダを 名前 => 値 のハッシュに変換する。
+      def parse_cookie_header(raw_cookie)
+        return {} if raw_cookie.blank?
+
+        raw_cookie.split(/;\s*/).each_with_object({}) do |pair, cookies|
+          name, value = pair.split('=', 2)
+          next if value.nil?
+
+          name = CGI.unescape(name)
+          next if cookies.key?(name)
+
+          # 旧実装は値を '&' 区切りの複数値として扱っていたため、先頭の値を採用する
+          cookies[name] = CGI.unescape(value.split('&').first.to_s)
+        end
       end
 
       def auth_token

--- a/test/lib/yt_music/client_test.rb
+++ b/test/lib/yt_music/client_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module YtMusic
+  class ClientTest < ActiveSupport::TestCase
+    setup do
+      @original_cookie = ENV.fetch('YOUTUBE_MUSIC_COOKIE', nil)
+      Client.instance_variable_set(:@sapisid, nil)
+    end
+
+    teardown do
+      ENV['YOUTUBE_MUSIC_COOKIE'] = @original_cookie
+      Client.instance_variable_set(:@sapisid, nil)
+    end
+
+    test 'extracts SAPISID from a cookie header with multiple cookies' do
+      ENV['YOUTUBE_MUSIC_COOKIE'] = 'HSID=abc; SAPISID=xyz123; SSID=def'
+
+      assert_equal 'xyz123', Client.send(:sapisid)
+    end
+
+    test 'unescapes url encoded cookie values' do
+      ENV['YOUTUBE_MUSIC_COOKIE'] = 'HSID=abc; SAPISID=xyz%3D123'
+
+      assert_equal 'xyz=123', Client.send(:sapisid)
+    end
+
+    test 'takes the first value when the cookie value contains an ampersand' do
+      ENV['YOUTUBE_MUSIC_COOKIE'] = 'SAPISID=first&second'
+
+      assert_equal 'first', Client.send(:sapisid)
+    end
+
+    test 'prefers the first occurrence when the same cookie appears twice' do
+      ENV['YOUTUBE_MUSIC_COOKIE'] = 'SAPISID=first; SAPISID=second'
+
+      assert_equal 'first', Client.send(:sapisid)
+    end
+
+    test 'returns nil when the cookie environment variable is not set' do
+      ENV.delete('YOUTUBE_MUSIC_COOKIE')
+
+      assert_nil Client.send(:sapisid)
+    end
+
+    test 'returns nil when the cookie environment variable is empty' do
+      ENV['YOUTUBE_MUSIC_COOKIE'] = ''
+
+      assert_nil Client.send(:sapisid)
+    end
+
+    test 'returns nil when the cookie header has no SAPISID' do
+      ENV['YOUTUBE_MUSIC_COOKIE'] = 'HSID=abc; SSID=def'
+
+      assert_nil Client.send(:sapisid)
+    end
+
+    test 'ignores malformed entries without a delimiter' do
+      ENV['YOUTUBE_MUSIC_COOKIE'] = 'broken; SAPISID=xyz123'
+
+      assert_equal 'xyz123', Client.send(:sapisid)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

管理画面のアクション「YouTube Music アルバムを取得」（`Admin::Actions::FetchYtmusicAlbum`）実行時に `uninitialized constant CGI::Cookie` エラーが発生していた問題を修正します。

## 原因

Ruby 4.0.3 では標準の `cgi` ライブラリが escape/unescape 系のみに縮小され、`CGI::Cookie` が完全に削除されています。

```
ruby 4.0.3 → CGI.const_defined?(:Cookie) #=> false
             require "cgi/cookie"        #=> LoadError
```

`YtMusic::Client#sapisid` が `CGI::Cookie.parse` に依存していたため、認証トークン生成時に例外が発生していました。

## 変更内容

- `YtMusic::Client#sapisid` を `CGI::Cookie` に依存しない自前の Cookie ヘッダ解析（`parse_cookie_header`）に置き換え
  - 旧 `CGI::Cookie.parse` 相当の挙動を維持（`CGI.unescape`、`&` 区切り値の先頭採用、同名 Cookie の先頭優先、`=` なし要素のスキップ）
- 環境変数 `YOUTUBE_MUSIC_COOKIE` が未設定・空文字の場合は例外を投げずに `nil` を返すよう改善
- `YtMusic::Client` のテストを新規追加（8ケース）
- devbox.lock の nodejs@20 プラグインバージョンを更新（0.0.2 → 0.0.4）

## 動作確認

- `bin/rails test test/lib/yt_music` → 9 runs, 15 assertions, 0 failures, 0 errors（修正前は `NameError` で失敗することを確認済み）
- `make rubocop` → 227 files inspected, no offenses detected
- `grep -rn "CGI::Cookie" lib app test` → マッチなし

## 注意

`YOUTUBE_MUSIC_COOKIE` 未設定時は例外ではなく `sapisid` が `nil` になります。認証は通らないため、実際の取得動作は環境変数設定のうえで確認してください。