### PR TITLE
CLAUDE.mdのAvo前提の記述を現状に合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ touhou_music_discover (東方同人音楽流通) is a Rails application that tra
 - **Circle** (doujin groups) ← **CirclesAlbum** → **Album**
 
 ### Admin Interface
-Uses Avo framework at `/avo` for data management with custom actions for:
+A self-built admin interface (not a gem) mounted at `/admin`, with controllers under `app/controllers/admin/`. Data-fetching and operational actions are defined as action classes in `app/models/admin/actions.rb`, each inheriting from `Admin::Actions::BaseAction`, for:
 - Fetching data from streaming platforms
 - Bulk operations
 - Data export/import
@@ -87,9 +87,9 @@ make docker-migrate   # Dockerでマイグレーション
 
 ## Key Workflows
 
-1. **Adding New Albums**: Use Avo actions to fetch from platforms, then associate with circles and original songs
+1. **Adding New Albums**: Use admin actions (`Admin::Actions::*`) to fetch from platforms, then associate with circles and original songs
 2. **Data Export**: Use rake tasks for Algolia search or random selection app exports
-3. **Platform Updates**: Each platform has separate update actions in Avo to refresh metadata
+3. **Platform Updates**: Each platform has separate update actions in the admin actions system to refresh metadata
 
 ## Important Conventions
 
@@ -97,7 +97,7 @@ make docker-migrate   # Dockerでマイグレーション
 - Use UUIDs for primary keys
 - JAN codes identify albums, ISRC codes identify tracks
 - Touhou flag (`is_touhou`) determines if content is actually Touhou-related
-- Use Avo actions for all data fetching operations to maintain consistency
+- Implement data fetching operations as action classes inheriting from `Admin::Actions::BaseAction` in `app/models/admin/actions.rb` to maintain consistency
 
 ## Development Workflow
 When making code modifications:


### PR DESCRIPTION
## 概要

Avo gem は既に撤廃され自作の管理画面へ移行済みですが、`CLAUDE.md` に Avo 前提の記述が残っていたため、現状に合わせて更新します。

## 変更内容

`CLAUDE.md` の以下4箇所を修正しました（英語表記のまま統一）。

### Admin Interface セクション

- 変更前: ``Uses Avo framework at `/avo` for data management with custom actions for:``
- 変更後: ``A self-built admin interface (not a gem) mounted at `/admin`, with controllers under `app/controllers/admin/`. Data-fetching and operational actions are defined as action classes in `app/models/admin/actions.rb`, each inheriting from `Admin::Actions::BaseAction`, for:``

### Key Workflows

- 1番: `Use Avo actions to fetch from platforms` → ``Use admin actions (`Admin::Actions::*`) to fetch from platforms``
- 3番: `separate update actions in Avo` → `separate update actions in the admin actions system`

### Important Conventions

- 変更前: `Use Avo actions for all data fetching operations to maintain consistency`
- 変更後: ``Implement data fetching operations as action classes inheriting from `Admin::Actions::BaseAction` in `app/models/admin/actions.rb` to maintain consistency``

## 記述の根拠

- ルーティング: `config/routes.rb` の `namespace :admin`（root は `admin/dashboard#show`）
- コントローラ: `app/controllers/admin/` 配下
- アクション: `app/models/admin/actions.rb` の `Admin::Actions::BaseAction` 継承クラス群

## 動作確認

- ドキュメントのみの変更（コード変更なし）
- `grep -rn -i "avo" CLAUDE.md` → マッチなし