### PR TITLE
アーティスト名からサークル名へのマッピングを追加

### DIFF
--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -39,7 +39,8 @@ class Circle < ApplicationRecord
     'ともきち' => '幻光庭',
     'askey' => '.new label',
     '激戦の人' => '激戦魂 -Gekisen Soul-',
-    'ぱらどっと' => '給食頭蛮'
+    'ぱらどっと' => '給食頭蛮',
+    '坂本昌一郎' => 'sound sepher'
   }.freeze
 
   JAN_TO_CIRCLE = {


### PR DESCRIPTION
## 概要

`Circle::ARTIST_TO_CIRCLE` に アーティスト名 → サークル名 の対応を1件追加しました。

## 変更内容

- `坂本昌一郎` → `sound sepher` のマッピングを追加（`app/models/circle.rb`）

## 影響範囲

各プラットフォームから取得したアーティスト名をサークルに紐付ける処理で、`坂本昌一郎` 名義の作品が `sound sepher` サークルに正しく関連付けられるようになります。

## 確認事項

- [x] RuboCop 実行済み（227ファイル、違反なし）
- [x] テスト実行済み（116 runs, 978 assertions, 0 failures, 0 errors）