### PR TITLE
既知の脆弱性13件を解消するgem更新とsolid_queue 1.5への引き上げ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,4 @@ gem 'retryable'
 gem 'rspotify'
 gem 'spotify-client', require: 'spotify/client'
 
-gem 'solid_queue', '~> 1.4'
+gem 'solid_queue', '~> 1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,20 +77,22 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.10)
       public_suffix (>= 2.0.2, < 8.0)
-    amatch (0.6.0)
+    amatch (0.7.0)
       mize
       tins (~> 1)
+    anonymous_loader (0.1.3)
+      version_gem (~> 1.1, >= 1.1.14)
     ast (2.4.3)
-    auth-sanitizer (0.1.4)
-      version_gem (~> 1.1, >= 1.1.9)
+    auth-sanitizer (0.2.3)
+      version_gem (~> 1.1, >= 1.1.14)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    bootsnap (1.24.5)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
     builder (3.3.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
@@ -104,33 +106,33 @@ GEM
       dotenv (= 3.2.0)
       railties (>= 6.1)
     drb (2.2.3)
-    erb (6.0.4)
+    erb (6.0.6)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
-    excon (1.4.2)
+    excon (1.6.0)
       logger
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.3)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
-    fugit (1.12.1)
+    fugit (1.13.0)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
-    globalid (1.3.0)
+    globalid (1.4.0)
       activesupport (>= 6.1)
     hashie (5.1.0)
       logger
     http-cookie (1.1.6)
       domain_name (~> 0.5)
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     irb (1.18.0)
@@ -140,7 +142,7 @@ GEM
       reline (>= 0.4.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.5)
+    json (2.21.1)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
@@ -150,7 +152,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -169,12 +171,12 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     mize (0.6.1)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -185,21 +187,22 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.5)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth2 (2.0.20)
-      auth-sanitizer (~> 0.1, >= 0.1.3)
+    oauth2 (2.0.25)
+      anonymous_loader (~> 0.1, >= 0.1.3)
+      auth-sanitizer (~> 0.2, >= 0.2.3)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.4)
-      version_gem (~> 1.1, >= 1.1.9)
+      snaky_hash (~> 2.0, >= 2.0.7)
+      version_gem (~> 1.1, >= 1.1.14)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
@@ -212,7 +215,7 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     ostruct (0.6.3)
-    pagy (43.5.4)
+    pagy (43.6.1)
       json
       uri
       yaml
@@ -223,7 +226,7 @@ GEM
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -231,15 +234,12 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    psych (5.3.1)
-      date
-      stringio
     public_suffix (7.0.5)
-    puma (8.0.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
-    raabro (1.4.0)
+    raabro (1.5.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-protection (4.2.1)
@@ -271,8 +271,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -292,9 +292,14 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (7.2.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     readline (0.0.4)
       reline
@@ -340,10 +345,10 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    snaky_hash (2.0.4)
+    snaky_hash (2.0.7)
       hashie (>= 0.1.0, < 6)
-      version_gem (>= 1.1.8, < 3)
-    solid_queue (1.4.0)
+      version_gem (~> 1.1, >= 1.1.14)
+    solid_queue (1.5.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
       concurrent-ruby (>= 1.3.1)
@@ -354,11 +359,10 @@ GEM
       excon (>= 1.4, < 2.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.2.0)
     sync (0.5.0)
     thor (1.5.0)
     timeout (0.6.1)
-    tins (1.54.0)
+    tins (1.55.0)
       bigdecimal
       mize (~> 0.6)
       readline
@@ -374,8 +378,8 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    version_gem (1.1.9)
-    websocket-driver (0.8.0)
+    version_gem (1.1.14)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -418,7 +422,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
-  solid_queue (~> 1.4)
+  solid_queue (~> 1.5)
   spotify-client
   stimulus-rails
   turbo-rails


### PR DESCRIPTION
## 概要

`bundler-audit` で検出された既知の脆弱性のうち、解消可能な13件を修正します。
あわせて計画済みの直接依存の更新と solid_queue の pin 引き上げを行います。

## 解消したCVE（13 gem）

| gem | 更新前 → 更新後 | 深刻度 |
|---|---|---|
| concurrent-ruby | 1.3.6 → 1.3.8 | Medium |
| crass | 1.0.6 → 1.0.7 | - |
| excon | 1.4.2 → 1.6.0 | Medium |
| faraday | 2.14.2 → 2.14.3 | High |
| json | 2.19.5 → 2.21.1 | Low |
| loofah | 2.25.1 → 2.25.2 | Medium |
| msgpack | 1.8.0 → 1.8.3 | - |
| net-imap | 0.6.4 → 0.6.6 | Medium |
| nokogiri | 1.19.3 → 1.19.4 | - |
| oauth2 | 2.0.20 → 2.0.25 | High |
| puma | 8.0.1 → 8.0.2 | High |
| rails-html-sanitizer | 1.7.0 → 1.7.1 | - |
| websocket-driver | 0.8.0 → 0.8.2 | High |

## あわせて更新した直接依存

- amatch 0.6.0 → 0.7.0
- bootsnap 1.24.5 → 1.24.6
- pagy 43.5.4 → 43.6.1
- solid_queue 1.4.0 → 1.5.0（Gemfile の pin を `~> 1.4` → `~> 1.5`）

`bin/rails solid_queue:install:migrations` を実行し、**新規マイグレーションが発生しないこと**を確認済み。`db/queue_schema.rb` の変更もありません。

rubocop 系は差分を読みやすくするため本PRから除外し、別PRで対応します。

## 残存する脆弱性

`addressable 2.8.10` の CVE-2026-35611（High / Addressable templates の ReDoS）は、`rspotify 2.12.4` が `addressable (~> 2.8.0)` を固定しているため本PRでは解消できません。

- ReDoS は URI テンプレートを攻撃者が制御できる場合の問題で、本アプリに到達経路はないと判断
- 根本解決には rspotify → spotify-client への移行が必要（別Issue化予定。同移行は 2016年製の `rest-client 2.0.2` 固定も同時に解消する）

## 検証

- `bundler-audit check --update` → 残るのは上記 addressable のみ
- `RAILS_ENV=test bin/rails zeitwerk:check` → All is good!
- `bin/rails test` → 116 runs, 978 assertions, 0 failures, 0 errors, 0 skips
- `rubocop --parallel` → 227 files inspected, no offenses detected
- amatch 0.7.0 の動作確認: `lib/similar.rb` が使う API は健在。`test/services/` 通過（サークル自動紐付けの閾値判定に影響なし）