### PR TITLE
JSツールチェーンをyarn 1.22に統一しNode.jsを24 LTSへ更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ make console       # Railsコンソール
 make shell         # devboxシェルに入る
 ```
 
+JSのパッケージマネージャーはyarn 1.22を使用する（bunは使用しない）。
+
 ### Database Operations
 ```bash
 make migrate       # マイグレーション実行

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ruby:4.0.3
 
 WORKDIR /app
 
-# Using Node.js v20.x(LTS)
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+# Using Node.js v24.x(LTS)
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
 
 # Add packages
 RUN apt-get update && apt-get install -y \
@@ -13,4 +13,4 @@ RUN apt-get update && apt-get install -y \
       vim
 
 # Add yarnpkg for assets:precompile
-RUN npm install -g yarn
+RUN npm install -g yarn@1.22.22

--- a/devbox.json
+++ b/devbox.json
@@ -4,7 +4,7 @@
     "ruby":          "4.0.3",
     "postgresql_18": "18.1",
     "redis":         "8.2.3",
-    "nodejs":        "20",
+    "nodejs":        "24",
     "yarn":          "1.22",
     "libyaml":       "0.2.5",
     "openssl":       "3.6.0",

--- a/devbox.lock
+++ b/devbox.lock
@@ -195,84 +195,84 @@
         }
       }
     },
-    "nodejs@20": {
-      "last_modified": "2026-01-24T23:43:55Z",
+    "nodejs@24": {
+      "last_modified": "2025-12-27T12:56:01Z",
       "plugin_version": "0.0.4",
-      "resolved": "github:NixOS/nixpkgs/26b0093bc977081dc7653175a3fadab11e07bed7#nodejs_20",
+      "resolved": "github:NixOS/nixpkgs/3edc4a30ed3903fdf6f90c837f961fa6b49582d1#nodejs_24",
       "source": "devbox-search",
-      "version": "20.20.0",
+      "version": "24.12.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/lpxs72iagg4hxnd8swgpvaiajgpdiaiv-nodejs-20.20.0",
+              "path": "/nix/store/b1h0af3yb3z9jz048phclcqw6ihiww67-nodejs-24.12.0",
               "default": true
             },
             {
               "name": "dev",
-              "path": "/nix/store/ffv0m7yqk3zdrjcbz030l5h4drd3qpxi-nodejs-20.20.0-dev"
+              "path": "/nix/store/ksn4nj0nbp0ikmh4scy9x4biqqdswwhy-nodejs-24.12.0-dev"
             },
             {
               "name": "libv8",
-              "path": "/nix/store/na6qprgp6izbr2acc67rv45i8f567c61-nodejs-20.20.0-libv8"
+              "path": "/nix/store/3x72bm7l30ib7l7cximrp0sklcq8jqwy-nodejs-24.12.0-libv8"
             }
           ],
-          "store_path": "/nix/store/lpxs72iagg4hxnd8swgpvaiajgpdiaiv-nodejs-20.20.0"
+          "store_path": "/nix/store/b1h0af3yb3z9jz048phclcqw6ihiww67-nodejs-24.12.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/j99h1wchrxq7yjgsgdfzpb471gd9ffzz-nodejs-20.20.0",
+              "path": "/nix/store/9jfsyhcr9c6rpm94lrkibv75jkggvwss-nodejs-24.12.0",
               "default": true
             },
             {
               "name": "dev",
-              "path": "/nix/store/sj3dkxdbgi6aw7bdw3y4g6f1p3167mzi-nodejs-20.20.0-dev"
+              "path": "/nix/store/7izhv9x1yvsmyrhmmyps6bxjjclajm80-nodejs-24.12.0-dev"
             },
             {
               "name": "libv8",
-              "path": "/nix/store/w43cfcpz1d205xwixvyb0wnrq62nfs5r-nodejs-20.20.0-libv8"
+              "path": "/nix/store/8hl74pnc1qyz68rg10ixw7fz32hcxqkk-nodejs-24.12.0-libv8"
             }
           ],
-          "store_path": "/nix/store/j99h1wchrxq7yjgsgdfzpb471gd9ffzz-nodejs-20.20.0"
+          "store_path": "/nix/store/9jfsyhcr9c6rpm94lrkibv75jkggvwss-nodejs-24.12.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/93b8p46bmm8qrwymi6aw99h8n0nnni03-nodejs-20.20.0",
+              "path": "/nix/store/cj1243xswxvnwgifyiyg8axhn0r2vl48-nodejs-24.12.0",
               "default": true
             },
             {
-              "name": "libv8",
-              "path": "/nix/store/0g5s1xy86aqbi1cfa35z63rak73hki6y-nodejs-20.20.0-libv8"
+              "name": "dev",
+              "path": "/nix/store/kzia3rkaf9vwpn3py23q9v49jpjm6zx7-nodejs-24.12.0-dev"
             },
             {
-              "name": "dev",
-              "path": "/nix/store/gafdza0dkjvhqsx0xlmi1wsgw1ha6ash-nodejs-20.20.0-dev"
+              "name": "libv8",
+              "path": "/nix/store/xszji81xj7ghjhz7jk0jkhb84nfwyd8f-nodejs-24.12.0-libv8"
             }
           ],
-          "store_path": "/nix/store/93b8p46bmm8qrwymi6aw99h8n0nnni03-nodejs-20.20.0"
+          "store_path": "/nix/store/cj1243xswxvnwgifyiyg8axhn0r2vl48-nodejs-24.12.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/mcy5n3l8z7dbvaic7kgh80b86xj7smkn-nodejs-20.20.0",
+              "path": "/nix/store/9z1v3wyrxp6fpyzw21lcakd5w7aknzyc-nodejs-24.12.0",
               "default": true
             },
             {
               "name": "libv8",
-              "path": "/nix/store/7sljbl366m4vlf79va6l4441j1qmpjax-nodejs-20.20.0-libv8"
+              "path": "/nix/store/5yvx909wlis13qd2y1ahwl7ij21ma69a-nodejs-24.12.0-libv8"
             },
             {
               "name": "dev",
-              "path": "/nix/store/p6c5l3l0p5cymnzybcyil9dqbiymi6ly-nodejs-20.20.0-dev"
+              "path": "/nix/store/7ll99p08gmpg0n048669p80zjibl5akr-nodejs-24.12.0-dev"
             }
           ],
-          "store_path": "/nix/store/mcy5n3l8z7dbvaic7kgh80b86xj7smkn-nodejs-20.20.0"
+          "store_path": "/nix/store/9z1v3wyrxp6fpyzw21lcakd5w7aknzyc-nodejs-24.12.0"
         }
       }
     },


### PR DESCRIPTION
## 概要

Node.js 20 は 2026年4月に EOL を迎えておりセキュリティ更新が提供されません。Active LTS である Node 24 へ更新します。あわせて `yarn.lock` と `bun.lock` の二重管理を解消し、yarn 1.22 に一本化します。

## 変更内容

### Node.js 20 → 24 LTS
- `devbox.json` の `nodejs` を `20` → `24`（devbox 解決結果: 20.20.0 → 24.12.0）
- `Dockerfile` の nodesource を `setup_20.x` → `setup_24.x`

`.node-version`（`24`）は前PRで追加済みのため変更なし。CI は `actions/setup-node@v6` がこれを参照します。

### yarn への一本化
- 未追跡だった `bun.lock` を削除。`process-compose.yaml` / `devbox.json` / `Dockerfile` / CI はいずれも元から yarn 前提だったため、bun 側は実質使われていませんでした
- `.gitignore` の `bun.lock` の記述は誤コミット防止として維持
- `Dockerfile` の `npm install -g yarn` を `yarn@1.22.22` にバージョン固定（corepack は Node 24 で deprecated のため使用しません）
- `CLAUDE.md` にパッケージマネージャーの方針を1行明記

## devbox.lock の差分について

`devbox install` で再生成しました。差分は **`nodejs` パッケージのブロックのみ**（version / resolved ハッシュ / 各システムの nix store パス）で、`ruby` / `postgresql_18` / `redis` / `yarn` / `libyaml` / `openssl` / `zlib` / `readline` / `libffi` / `libpq` はいずれも動いていないことを確認済みです。

## 検証

- `node --version` → `v24.12.0`、`yarn --version` → `1.22.22`
- `yarn install --frozen-lockfile` → `success Already up-to-date.`（**`yarn.lock` は無変更**）
- `yarn build && yarn build:css` → `application.js` 322.2kb / `application.css` 生成を確認（一度削除して再生成し、内容が正しく出力されることも確認）
- `RAILS_ENV=test bin/rails test` → 116 runs, 978 assertions, 0 failures, 0 errors, 0 skips
- `bundle exec rubocop --parallel` → 227 files inspected, no offenses detected