### PR TITLE
RuboCopを1.88へ更新しTargetRubyVersionを明示

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ plugins:
   - rubocop-performance
 
 AllCops:
+  TargetRubyVersion: 4.0
   NewCops: enable
   DisplayCopNames: true
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     json (2.21.1)
     jwt (3.2.0)
       base64
-    language_server-protocol (3.17.0.5)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     listen (3.10.0)
       logger
@@ -225,7 +225,7 @@ GEM
       uri
       yaml
     parallel (2.1.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pg (1.6.3-arm64-darwin)
@@ -324,7 +324,7 @@ GEM
       addressable (~> 2.8.0)
       omniauth-oauth2 (>= 1.6)
       rest-client (~> 2.0.2)
-    rubocop (1.86.2)
+    rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -335,14 +335,14 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.2)
+    rubocop-rails (2.36.0)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)


### PR DESCRIPTION
## 概要

RuboCop 系を最新へ更新し、あわせて `TargetRubyVersion` を明示します。

| gem | 更新前 → 更新後 |
|---|---|
| rubocop | 1.86.2 → 1.88.2 |
| rubocop-rails | 2.35.2 → 2.36.0 |
| rubocop-ast | 1.49.1 → 1.50.0（transitive） |
| parser | 3.3.11.1 → 3.3.12.0（transitive） |
| language_server-protocol | 3.17.0.5 → 3.17.0.6（transitive） |

`rubocop-performance` は 1.26.1 のまま（最新）。**RuboCop 系以外の gem は1つも動いていません。**

## TargetRubyVersion の明示

`.rubocop.yml` の `AllCops` に `TargetRubyVersion: 4.0` を追加しました。従来は未指定で `.ruby-version` からの推測に依存しており、RuboCop 側の推測ロジックが変わると挙動が変わりうる状態でした。

`.rubocop_base.yml` ではなく `.rubocop.yml` に追加した理由: `AllCops`（`NewCops` / `DisplayCopNames` / `Exclude`）は既に `.rubocop.yml` にのみ存在し、`.rubocop_base.yml` は per-cop の上書きだけを持つため。設定を分散させないようにしました。

## 新規 cop の指摘

`.rubocop.yml` に `NewCops: enable` があるため 1.87 / 1.88 で追加された cop が即座に有効化されますが、**指摘は0件**でした。安全な autocorrect（`--autocorrect`）も実行しましたが、変更するコードはありませんでした。挙動を変えうる unsafe autocorrect（`--autocorrect-all`）は使用していません。

## 検証

- `bundle exec rubocop --version` → `1.88.2`
- `bundle exec rubocop --parallel` → 227 files inspected, no offenses detected
- `RAILS_ENV=test bin/rails test` → 116 runs, 978 assertions, 0 failures, 0 errors, 0 skips
- `RAILS_ENV=test bin/rails zeitwerk:check` → All is good!
- `bundle exec brakeman --no-pager -q -w2` → exit 0
- `bundle exec bundler-audit check --update --ignore CVE-2026-35611` → exit 0

## 補足（このPRでは対応しない）

RuboCop が毎回「`rubocop-minitest` を導入してはどうか」という Tip を出します。本リポジトリは minitest のテストが45ファイルあり、`Minitest/AssertEmptyLiteral` や `Minitest/RefuteEqual` など plain な rubocop では検出できない指摘を拾えるため導入する価値はありますが、本PRのスコープ（バージョン更新）から外れるため別途対応とします。