### PR TITLE
エクスポートテストの並列実行時の競合を修正

### DIFF
--- a/test/lib/tasks/touhou_music_discover_export_test.rb
+++ b/test/lib/tasks/touhou_music_discover_export_test.rb
@@ -13,8 +13,6 @@ class TouhouMusicDiscoverExportTest < ActiveSupport::TestCase
   setup do
     Rake::Task['touhou_music_discover:export:spotify'].reenable
     Rake::Task['touhou_music_discover:export:touhou_music_with_original_songs'].reenable
-    FileUtils.rm_f(SPOTIFY_EXPORT_PATH)
-    FileUtils.rm_f(TOUHOU_MUSIC_WITH_ORIGINAL_SONGS_EXPORT_PATH)
   end
 
   test 'spotify export outputs active spotify albums only' do
@@ -27,9 +25,11 @@ class TouhouMusicDiscoverExportTest < ActiveSupport::TestCase
     create_spotify_track(album: active_album, track: active_track, spotify_album: active_spotify_album, spotify_id: 'export-active-spotify-track', name: 'Export Active Spotify Track')
     create_spotify_track(album: inactive_album, track: inactive_track, spotify_album: inactive_spotify_album, spotify_id: 'export-inactive-spotify-track', name: 'Export Inactive Spotify Track')
 
+    # tmp/export/ は並列ワーカープロセス間で共有されるため、自テストの出力ファイルのみを削除する
+    export_path = reset_export(SPOTIFY_EXPORT_PATH)
     Rake::Task['touhou_music_discover:export:spotify'].invoke
 
-    output = SPOTIFY_EXPORT_PATH.read
+    output = export_path.read
     assert_includes output, 'Export Active Spotify Album'
     assert_includes output, 'Export Active Spotify Track'
     assert_not_includes output, 'Export Inactive Spotify Album'
@@ -59,11 +59,13 @@ class TouhouMusicDiscoverExportTest < ActiveSupport::TestCase
       end
     end
 
+    # tmp/export/ は並列ワーカープロセス間で共有されるため、自テストの出力ファイルのみを削除する
+    export_path = reset_export(TOUHOU_MUSIC_WITH_ORIGINAL_SONGS_EXPORT_PATH)
     original_song_queries = count_original_song_selects do
       Rake::Task['touhou_music_discover:export:touhou_music_with_original_songs'].invoke
     end
 
-    output = TOUHOU_MUSIC_WITH_ORIGINAL_SONGS_EXPORT_PATH.read
+    output = export_path.read
     tracks.each { |track| assert_includes output, track.isrc }
     original_songs.each { |original_song| assert_includes output, original_song.title }
     assert_operator original_song_queries, :<=, 1
@@ -109,5 +111,13 @@ class TouhouMusicDiscoverExportTest < ActiveSupport::TestCase
       duration_ms: 180_000,
       payload: {}
     )
+  end
+
+  # テストDBはRailsがワーカーごとに分離するが、tmp/export/ は分離されず全ワーカープロセスで共有される。
+  # そのため setup で全出力ファイルを消すと他テストの出力を消してしまい競合するので、
+  # 各テストが自分の使うパスだけをrake実行直前にリセットする。
+  def reset_export(path)
+    FileUtils.rm_f(path)
+    path
   end
 end


### PR DESCRIPTION
## 概要

`TouhouMusicDiscoverExportTest` が並列実行時にランダムに失敗する既存のフレーキーテストを修正します。

PR #549 の CI（seed 54564）で顕在化しました。

```
TouhouMusicDiscoverExportTest#test_touhou_music_with_original_songs_export_preloads_original_songs:
Errno::ENOENT: No such file or directory @ rb_sysopen -
  .../tmp/export/touhou_music_with_original_songs.tsv
    test/lib/tasks/touhou_music_discover_export_test.rb:66:in 'Pathname#read'
```

## 原因

このテストクラスの2つのテストは、それぞれ**異なる**ファイルに出力する rake タスクを叩きます。

- `spotify export ...` → `tmp/export/spotify_touhou_music.tsv`
- `touhou music with original songs export ...` → `tmp/export/touhou_music_with_original_songs.tsv`

しかし共有の `setup` ブロックが、どちらのテストの実行時にも**両方**のファイルを削除していました。

```ruby
setup do
  ...
  FileUtils.rm_f(SPOTIFY_EXPORT_PATH)
  FileUtils.rm_f(TOUHOU_MUSIC_WITH_ORIGINAL_SONGS_EXPORT_PATH)   # ← 他テストの出力も消す
end
```

`test/test_helper.rb` は `parallelize(workers: :number_of_processors)` を有効にしており、Minitest の並列ワーカーは**ファイルシステムを共有する別プロセス**です。**テストDBはRailsがワーカーごとに分離しますが、`tmp/export/` は分離されません。**

結果として以下の順序が起きると失敗します。

1. Worker B がテスト2を実行し、rake タスクが `touhou_music_with_original_songs.tsv` を書き出す
2. Worker A がテスト1を開始し、その `setup` が**両方**のファイルを削除（Bが今書いたファイルを含む）
3. Worker B が `.read` に到達 → `Errno::ENOENT`

タイミング依存のため、これまでは seed によって通ったり落ちたりしていました。

## 修正

`setup` からファイル削除を撤去し、各テストが**自分の使うパスだけ**を rake 実行の直前にリセットするようにしました。

```ruby
# tmp/export/ は並列ワーカープロセス間で共有されるため、自テストの出力ファイルのみを削除する
export_path = reset_export(SPOTIFY_EXPORT_PATH)
```

削除と読み出しを同じローカル変数経由にすることで、対象が一致することがコード上で保証されます。

**競合が構造的に不可能になった理由**: `FileUtils.rm_f` はヘルパー内の1箇所のみに存在し、呼び出し2箇所が渡すパスは互いに素です。どちらのテストも相手のパスを名指ししないため、並列ワーカーがどう交錯しても他テストが読もうとしているファイルを削除できません。タイミングウィンドウを狭めたのではなく、経路自体を排除しています。

`lib/tasks/touhou_music_discover.rake`（本番の rake タスク）と `test/test_helper.rb` は変更していません。並列実行も無効化していません。

## 検証

タイミング依存の不具合なので1回の緑では意味がないため、seed を変えて繰り返し実行しました。

- **全テストスイート × 10回**: すべて `116 runs, 978 assertions, 0 failures, 0 errors, 0 skips`
- **該当ファイル単体 × 3回**: すべて `2 runs, 18 assertions, 0 failures, 0 errors, 0 skips`
- `bundle exec rubocop --parallel` → 227 files inspected, no offenses detected