### PR TITLE
config.load_defaults を 8.1 に引き上げ

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ Bundler.require(*Rails.groups)
 module TouhouMusicDiscover
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 8.0
+    config.load_defaults 8.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
## 概要

Rails 8.1.3 を使用しているのに `config.load_defaults` が 8.0 のままだったため、8.1 に引き上げます。

**差分は `config/application.rb` の1行のみ**ですが、フレームワークの挙動が7箇所変わるため、それぞれ本アプリで安全であることを実証してからマージします。

## 8.1 が追加する設定は厳密に7項目

`railties-8.1.3/lib/rails/application/configuration.rb:343-367` から抽出した実際のコードです。

```ruby
self.yjit = !Rails.env.local?
action_controller.escape_json_responses = false
action_controller.action_on_path_relative_redirect = :raise
active_record.raise_on_missing_required_finder_order_columns = true
active_support.escape_js_separators_in_json = false
action_view.render_tracker = :ruby
action_view.remove_hidden_field_autocomplete = true
```

## 各項目の安全性の根拠

### 1. `action_on_path_relative_redirect = :raise`
パス相対（先頭 `/` なし）のリダイレクト先を渡すと例外になります。

`app/` 配下の `redirect_to` **全29箇所**を分類したところ、**すべてが `*_path` / `*_url` のルートヘルパー**でした（`root_path` / `root_url` / `spotify_playlists_path` / `admin_resource_path(...)` / `admin_resources_path(...)` / `action_run_path(run_id)` / `admin_track_original_song_assignments_path(...)`）。文字列リテラルや `params` 由来のリダイレクトは**0件**。

対象コントローラ: `sessions_controller.rb`, `spotify/playlists_controller.rb`, `admin/resources_controller.rb`, `admin/actions_controller.rb`, `admin/relations_controller.rb`, `admin/original_song_assignments_controller.rb`

### 2. `raise_on_missing_required_finder_order_columns = true`
暗黙の順序を持たないリレーションへの `.first` / `.last` / `.take` が、主キーへフォールバックできない場合に例外になります。

- `db/schema.rb`: `create_table` **21箇所**、`id: false` は**0件**
- `db/queue_schema.rb`: `create_table` **11箇所**、`id: false` は**0件**

内訳は 19テーブルが `id: :uuid`、`original_songs` / `originals` が `primary_key: "code", id: :string`、`master_artists` と solid_queue の11テーブルが暗黙の bigint 主キー。**全テーブルが主キーを持つ**ため常にフォールバックできます。

> 将来 `id: false` のテーブルを追加した場合は再燃しうる点にご注意ください。

### 3. `escape_json_responses = false` / `escape_js_separators_in_json = false`
JSON 中の `<` `>` `&` U+2028 U+2029 のエスケープが止まります。危険なのは JSON を `application/json` として返すのではなく HTML や `<script>` に埋め込んでいる場合です。

- **`render json:` は3アクションのみ**: `admin/original_song_assignments_controller#options`, `#resolve`, `admin/association_options_controller#index`。いずれも `content_type` の上書きもテンプレート描画もない純粋な JSON エンドポイントで、`Content-Type: application/json` として返されます
- **ビュー内の JSON 出力は1箇所のみ**: `app/views/admin/original_song_assignments/index.html.erb:107`
  ```erb
  data-admin-original-song-picker-initial-options-value="<%= json_escape(selected_options.to_json) %>"
  ```
  HTML 属性値なので ERB が自動エスケープし、さらに `json_escape()` が `<` `>` `&` U+2028/U+2029 を独自にエスケープします。この2つの設定とは無関係に二重で保護されています
- `raw` / `html_safe` と JSON の組み合わせは `app/views/` 全体で**0件**

### 4. `remove_hidden_field_autocomplete = true`
`form_with` / `button_to` が生成する hidden input から `autocomplete="off"` が消えます。

`test/` 全体で `autocomplete` に言及するアサーションは**0件**。なお唯一のコード中の `autocomplete="off"`（`index.html.erb:117`）は手書きの `<input type="search">` に対するもので、生成される hidden field ではないため影響を受けません。

### 5. `render_tracker = :ruby`
テンプレート依存の追跡が Prism ベースになるだけです。`config/environments/development.rb` は `enable_reloading = true` / `eager_load = false` / `perform_caching = false` で、フラグメントキャッシュを使っていません。

### 6. `yjit = !Rails.env.local?`
8.0 は全環境 true、8.1 は development / test で無効・production で有効になります。実測で確認済み（下記）。dev/test の boot はむしろ速くなります。

## solid_queue / Redis キャッシュ / propshaft / マルチDB への影響

**ありません。** 8.1 のデフォルトは Active Job、キャッシュのシリアライゼーション（`cache_format_version` / `message_serializer` は 7.1 導入・8.0 で有効済み）、アセットパイプライン、コネクションハンドリングのいずれにも触れません。**Redis キャッシュの一斉失効は起きません。**

## 検証

```
$ bin/rails runner 'puts RubyVM::YJIT.enabled?'                            # development
false
$ RAILS_ENV=production ... bin/rails runner 'puts RubyVM::YJIT.enabled?'
true

$ bin/rails runner '...' で6項目を実測
escape_json_responses                          => false
action_on_path_relative_redirect               => :raise
raise_on_missing_required_finder_order_columns => true
escape_js_separators_in_json                   => false
render_tracker                                 => :ruby
remove_hidden_field_autocomplete               => true
```

- `CI=true RAILS_ENV=test bin/rails test` → 116 runs, 978 assertions, 0 failures, 0 errors, 0 skips
- `RAILS_ENV=test bin/rails zeitwerk:check` → All is good!
- `RAILS_ENV=production SECRET_KEY_BASE=dummy bin/rails zeitwerk:check` → All is good!
- `bundle exec rubocop --parallel` → 208 files inspected, no offenses detected

## 切り戻しについて

問題が出た項目は initializer で個別に上書きすれば、`load_defaults` を戻さずに単独で無効化できます。