### PR TITLE
外部APIクライアントのタイムアウト・リトライ設定を共通化

### DIFF
--- a/lib/apple_music/client.rb
+++ b/lib/apple_music/client.rb
@@ -29,11 +29,12 @@ module AppleMusic
     attr_reader :config
 
     def connection
-      @connection ||= Faraday.new(url: API_URI) do |conn|
+      @connection ||= ExternalApi::Connection.build(:apple_music, url: API_URI, adapter: config.adapter) do |conn|
         conn.request :json
         conn.response :json, content_type: /\bjson$/
-        conn.adapter config.adapter
-        conn.headers['Authorization'] = "Bearer #{config.authentication_token}"
+        # Proc を渡すとリクエストごとに評価されるため、JWT の期限切れ後も
+        # 更新されたトークンが使われる（コネクション生成時の値に固定されない）。
+        conn.request :authorization, 'Bearer', -> { config.authentication_token }
       end
     end
 

--- a/lib/apple_music/config.rb
+++ b/lib/apple_music/config.rb
@@ -4,6 +4,10 @@ require 'jwt'
 
 module AppleMusic
   class Config
+    # 発行する JWT の有効期間と、期限切れ前に再発行を始めるマージン。
+    TOKEN_TTL = 12.hours
+    REFRESH_MARGIN = 10.minutes
+
     attr_accessor :secret_key_path, :secret_key, :team_id, :music_id, :storefront, :adapter
 
     def initialize
@@ -13,21 +17,37 @@ module AppleMusic
       @music_id = ENV.fetch('APPLE_MUSIC_MUSIC_ID', nil)
       @storefront = ENV.fetch('APPLE_MUSIC_STOREFRONT', 'jp')
       @adapter = :net_http
+      # AppleMusic.config は単一インスタンスを共有するため、キャッシュの
+      # 判定と再生成をまとめて排他制御する。
+      @token_mutex = Mutex.new
     end
 
+    # ES256 の署名は毎回それなりのCPUコストがかかるため、有効期限までトークンを再利用する。
     def authentication_token
+      @token_mutex.synchronize do
+        @authentication_token = generate_authentication_token if token_refresh_required?
+        @authentication_token
+      end
+    end
+
+    private
+
+    def token_refresh_required?
+      @authentication_token.nil? || Time.current >= @token_expires_at - REFRESH_MARGIN
+    end
+
+    def generate_authentication_token
       private_key = OpenSSL::PKey::EC.new(secret_key_value)
+      @token_expires_at = Time.current + TOKEN_TTL
 
       payload = {
         iss: team_id,
-        iat: Time.now.to_i,
-        exp: Time.now.to_i + 86_400 # 24 hours
+        iat: Time.current.to_i,
+        exp: @token_expires_at.to_i
       }
 
       JWT.encode(payload, private_key, 'ES256', kid: music_id)
     end
-
-    private
 
     def secret_key_value
       return File.read(secret_key_path) if secret_key_path && File.exist?(secret_key_path)

--- a/lib/external_api/connection.rb
+++ b/lib/external_api/connection.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'faraday/retry'
+
+module ExternalApi
+  # 外部API向け Faraday コネクションの共通ビルダー。
+  #
+  # タイムアウト値とリトライ条件をこのファイル1か所に集約し、
+  # 各クライアントでは認証やエンコーディングなど、そのAPI固有の設定だけを行う。
+  module Connection
+    # 全プロファイル共通のリトライ条件。
+    #
+    # retry_statuses について:
+    #   faraday-retry (Faraday::Retry::Middleware#call) は、レスポンスの
+    #   ステータスが retry_statuses に含まれる場合にのみ Faraday::RetriableResponse を
+    #   送出してリトライを発生させる。待機時間を決める calculate_sleep_amount /
+    #   calculate_retry_after も同じ経路でしか呼ばれないため、Retry-After ヘッダが
+    #   尊重されるかどうかもこの指定に依存する。
+    #   つまり retry_statuses を省略すると、429 のレート制限はリトライされず
+    #   Retry-After も無視される。
+    #
+    # exceptions について:
+    #   接続断・タイムアウト系は再送で回復する見込みがあるためリトライ対象に含める。
+    SHARED_RETRY_OPTIONS = {
+      retry_statuses: [429, 500, 502, 503, 504],
+      exceptions: [
+        Faraday::ConnectionFailed,
+        Faraday::SSLError,
+        Faraday::TimeoutError,
+        Net::OpenTimeout,
+        Net::ReadTimeout,
+        Errno::ECONNRESET,
+        Errno::EHOSTUNREACH
+      ].freeze
+    }.freeze
+
+    # サービスごとのタイムアウト・リトライ設定。
+    #
+    # methods に :post を明示している理由:
+    #   faraday-retry の既定値 IDEMPOTENT_METHODS は %i[delete get head options put] で、
+    #   :post を含まない。YouTube Music の検索・browse は POST で行うため、
+    #   従来 yt_music クライアントに書かれていた retry 設定は実質一度も発火していなかった。
+    #   対象APIの POST はいずれも参照系（検索・取得）で再送しても副作用がないため、
+    #   明示的に :post をリトライ対象に含める。
+    PROFILES = {
+      yt_music: {
+        open_timeout: 5,
+        timeout: 15,
+        retry: { max: 3, interval: 0.5, backoff_factor: 2, max_interval: 10, interval_randomness: 0.3, methods: %i[get post] }
+      },
+      line_music: {
+        open_timeout: 5,
+        timeout: 10,
+        retry: { max: 3, interval: 1.0, backoff_factor: 2, max_interval: 15, interval_randomness: 0.5, methods: %i[get post] }
+      },
+      apple_music: {
+        open_timeout: 5,
+        timeout: 15,
+        retry: { max: 3, interval: 1.0, backoff_factor: 2, max_interval: 20, interval_randomness: 0.5, methods: %i[get post] }
+      },
+      github: {
+        open_timeout: 5,
+        timeout: 30,
+        retry: { max: 2, interval: 1.0, backoff_factor: 2, max_interval: 10, interval_randomness: 0.5, methods: %i[get] }
+      }
+    }.freeze
+
+    class UnknownService < ArgumentError; end
+
+    class << self
+      # 指定サービスのプロファイルを適用した Faraday::Connection を返す。
+      #
+      # ブロックを渡すと、リトライ設定の後・アダプタ設定の前に呼び出されるため、
+      # リクエスト/レスポンスミドルウェア（:json など）を追加できる。
+      def build(service, url: nil, adapter: nil, &block)
+        profile = PROFILES.fetch(service) do
+          raise UnknownService, "未定義の外部APIサービスです: #{service.inspect} (利用可能: #{PROFILES.keys.join(', ')})"
+        end
+
+        Faraday.new(url ? { url: } : {}) do |conn|
+          conn.options.open_timeout = profile[:open_timeout]
+          conn.options.timeout = profile[:timeout]
+          conn.request :retry, **profile[:retry], **SHARED_RETRY_OPTIONS
+          conn.response :logger, Rails.logger, headers: false, bodies: false if Rails.env.development?
+
+          block&.call(conn)
+
+          # Faraday はアダプタがハンドラスタックの末尾にあることを要求するため、
+          # 呼び出し側ブロックが何を追加しても最後に設定されるようここで呼ぶ。
+          conn.adapter(adapter || Faraday.default_adapter)
+        end
+      end
+    end
+  end
+end

--- a/lib/line_music/client.rb
+++ b/lib/line_music/client.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'faraday'
-require 'faraday/retry'
 
 module LineMusic
   class ApiError < StandardError; end
@@ -11,19 +9,17 @@ module LineMusic
   API_URI = 'https://music.line.me/api2/'
 
   class Client
+    # クラス変数へのメモ化を複数スレッドから同時に行うと、コネクションが二重に
+    # 生成されうるため排他制御する。
+    CLIENT_MUTEX = Mutex.new
+
     class << self
       def client
-        @client ||= Faraday.new(API_URI) do |conn|
-          conn.request :retry, max: 3,
-                               interval: 30,
-                               interval_randomness: 0,
-                               backoff_factor: 1,
-                               exceptions: [Faraday::ConnectionFailed, Faraday::TimeoutError]
-          conn.request :json
-          conn.response :json, content_type: /\bjson$/
-          conn.response :logger, Rails.logger, { headers: false, bodies: false } if Rails.env.development?
-          conn.options.open_timeout = 5
-          conn.options.timeout = 10
+        CLIENT_MUTEX.synchronize do
+          @client ||= ExternalApi::Connection.build(:line_music, url: API_URI) do |conn|
+            conn.request :json
+            conn.response :json, content_type: /\bjson$/
+          end
         end
       end
 

--- a/lib/tasks/touhou_music_discover.rake
+++ b/lib/tasks/touhou_music_discover.rake
@@ -415,7 +415,7 @@ namespace :touhou_music_discover do
       token = ENV.fetch('GITHUB_TOKEN', nil)
       if token.present?
         headers = { 'Authorization' => "token #{token}" }
-        response = Faraday.get(url, nil, headers)
+        response = ExternalApi::Connection.build(:github).get(url) { |req| req.headers.merge!(headers) }
         songs = CSV.new(response.body, col_sep: "\t", converters: nil, liberal_parsing: true, encoding: 'UTF-8', headers: true)
         songs = songs.read
         songs.inspect

--- a/lib/yt_music/client.rb
+++ b/lib/yt_music/client.rb
@@ -2,8 +2,6 @@
 
 require 'cgi'
 require 'digest/sha1'
-require 'faraday'
-require 'faraday/retry'
 
 module YtMusic
   class Client
@@ -15,6 +13,10 @@ module YtMusic
     YOUTUBE_VERSION = '2.20260501.00.00'
     YOUTUBE_API_KEY = 'AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30'
     YTM_PARAMS = "?alt=json&key=#{YOUTUBE_API_KEY}".freeze
+    # クラス変数へのメモ化を複数スレッドから同時に行うと、コネクションが二重に
+    # 生成されうるため排他制御する。
+    CLIENT_MUTEX = Mutex.new
+
     class << self
       def generate_body(options = {})
         context = initialize_context
@@ -58,16 +60,18 @@ module YtMusic
       private
 
       def client
-        @client ||= Faraday.new(YTM_BASE_API) do |conn|
-          conn.request :retry, max: 3, interval: 0.5, backoff_factor: 2, exceptions: [Faraday::ConnectionFailed, Faraday::SSLError, Net::OpenTimeout]
-          conn.response :json, content_type: /\bjson\z/
+        CLIENT_MUTEX.synchronize do
+          @client ||= ExternalApi::Connection.build(:yt_music, url: YTM_BASE_API) do |conn|
+            conn.response :json, content_type: /\bjson\z/
+          end
         end
       end
 
       def youtube_client
-        @youtube_client ||= Faraday.new(YOUTUBE_BASE_API) do |conn|
-          conn.request :retry, max: 3, interval: 0.5, backoff_factor: 2, exceptions: [Faraday::ConnectionFailed, Faraday::SSLError, Net::OpenTimeout]
-          conn.response :json, content_type: /\bjson\z/
+        CLIENT_MUTEX.synchronize do
+          @youtube_client ||= ExternalApi::Connection.build(:yt_music, url: YOUTUBE_BASE_API) do |conn|
+            conn.response :json, content_type: /\bjson\z/
+          end
         end
       end
 

--- a/test/lib/apple_music/config_test.rb
+++ b/test/lib/apple_music/config_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module AppleMusic
+  class ConfigTest < ActiveSupport::TestCase
+    setup do
+      @config = Config.new
+      @config.secret_key_path = nil
+      @config.secret_key = OpenSSL::PKey::EC.generate('prime256v1').to_pem
+      @config.team_id = 'TEAM_ID'
+      @config.music_id = 'MUSIC_ID'
+    end
+
+    test 'reuses the cached token while it is still valid' do
+      token = @config.authentication_token
+
+      assert_equal token, @config.authentication_token
+
+      travel_to Time.current + Config::TOKEN_TTL - Config::REFRESH_MARGIN - 1.minute do
+        assert_equal token, @config.authentication_token
+      end
+    end
+
+    test 'regenerates the token once the refresh margin is reached' do
+      token = @config.authentication_token
+
+      travel_to Time.current + Config::TOKEN_TTL - Config::REFRESH_MARGIN + 1.minute do
+        assert_not_equal token, @config.authentication_token
+      end
+    end
+
+    test 'issues a token whose exp matches TOKEN_TTL' do
+      issued_at = Time.current
+      payload, = JWT.decode(@config.authentication_token, nil, false)
+
+      assert_in_delta (issued_at + Config::TOKEN_TTL).to_i, payload['exp'], 5
+      assert_equal 'TEAM_ID', payload['iss']
+    end
+
+    test 'raises when no secret key is configured' do
+      @config.secret_key = nil
+
+      assert_raises(ParameterMissing) { @config.authentication_token }
+    end
+  end
+end

--- a/test/lib/external_api/connection_test.rb
+++ b/test/lib/external_api/connection_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ExternalApi
+  class ConnectionTest < ActiveSupport::TestCase
+    EXPECTED_TIMEOUTS = {
+      yt_music: { open_timeout: 5, timeout: 15 },
+      line_music: { open_timeout: 5, timeout: 10 },
+      apple_music: { open_timeout: 5, timeout: 15 },
+      github: { open_timeout: 5, timeout: 30 }
+    }.freeze
+
+    EXPECTED_TIMEOUTS.each do |service, expected|
+      test "#{service} profile applies the expected timeouts" do
+        conn = Connection.build(service, url: 'https://example.com')
+
+        assert_equal expected[:open_timeout], conn.options.open_timeout
+        assert_equal expected[:timeout], conn.options.timeout
+      end
+
+      test "#{service} profile installs the retry middleware" do
+        conn = Connection.build(service, url: 'https://example.com')
+
+        assert retry_handler?(conn), "#{service} には Faraday::Retry::Middleware が必要です"
+      end
+    end
+
+    test 'yields the connection before the adapter is set' do
+      conn = Connection.build(:github, url: 'https://example.com') do |builder|
+        builder.response :json
+      end
+
+      handler_names = conn.builder.handlers.map(&:klass)
+
+      assert_includes handler_names, Faraday::Response::Json
+      assert_equal Faraday::Adapter::NetHttp, conn.builder.adapter.klass
+    end
+
+    test 'uses the given adapter when specified' do
+      conn = Connection.build(:apple_music, url: 'https://example.com', adapter: :test)
+
+      assert_equal Faraday::Adapter::Test, conn.builder.adapter.klass
+    end
+
+    test 'raises for an unknown service' do
+      error = assert_raises(Connection::UnknownService) do
+        Connection.build(:unknown_service)
+      end
+
+      assert_match(/unknown_service/, error.message)
+    end
+
+    test 'every profile retries on rate limit and server error statuses' do
+      Connection::PROFILES.each_key do |service|
+        conn = Connection.build(service, url: 'https://example.com')
+        options = retry_handler(conn).instance_variable_get(:@kwargs)
+
+        assert_equal [429, 500, 502, 503, 504], options[:retry_statuses], "#{service} の retry_statuses が想定と異なります"
+      end
+    end
+
+    private
+
+    def retry_handler(conn)
+      conn.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }
+    end
+
+    def retry_handler?(conn)
+      retry_handler(conn).present?
+    end
+  end
+end

--- a/test/lib/line_music/client_test.rb
+++ b/test/lib/line_music/client_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module LineMusic
+  class ClientTest < ActiveSupport::TestCase
+    test 'client uses the shared line_music connection profile' do
+      conn = Client.client
+
+      assert_equal 5, conn.options.open_timeout
+      assert_equal 10, conn.options.timeout
+      assert_includes conn.builder.handlers.map(&:klass), Faraday::Retry::Middleware
+      assert_includes conn.builder.handlers.map(&:klass), Faraday::Request::Json
+      assert_includes conn.builder.handlers.map(&:klass), Faraday::Response::Json
+    end
+
+    test 'client is memoized' do
+      assert_same Client.client, Client.client
+    end
+
+    test 'delegates unknown methods to the underlying connection' do
+      assert_respond_to Client, :get
+      assert_equal API_URI, Client.url_prefix.to_s
+    end
+  end
+end

--- a/test/lib/yt_music/client_test.rb
+++ b/test/lib/yt_music/client_test.rb
@@ -61,5 +61,22 @@ module YtMusic
 
       assert_equal 'xyz123', Client.send(:sapisid)
     end
+
+    test 'client uses the shared yt_music connection profile' do
+      assert_yt_music_profile Client.send(:client)
+    end
+
+    test 'youtube_client uses the shared yt_music connection profile' do
+      assert_yt_music_profile Client.send(:youtube_client)
+    end
+
+    private
+
+    def assert_yt_music_profile(conn)
+      assert_equal 5, conn.options.open_timeout
+      assert_equal 15, conn.options.timeout
+      assert_includes conn.builder.handlers.map(&:klass), Faraday::Retry::Middleware
+      assert_includes conn.builder.handlers.map(&:klass), Faraday::Response::Json
+    end
   end
 end


### PR DESCRIPTION
## 概要

Faraday ベースの外部APIクライアント3つのタイムアウト／リトライ設定がバラバラで、うち2つは**設定そのものが存在しませんでした**。`ExternalApi::Connection` を追加して1ファイルに集約します。

## 修正した問題

| # | 問題 | 実害 |
|---|---|---|
| 1 | `lib/yt_music/client.rb` / `lib/apple_music/client.rb` に**タイムアウト設定が皆無** | 外部APIがハングするとバッチが無限待ち |
| 2 | **yt_music のリトライが一度も発火していなかった** | faraday-retry の既定 `IDEMPOTENT_METHODS` は `%i[delete get head options put]` で `:post` を含まない。YouTube Music の検索・browse は POST なので、書かれていた retry 設定は実質デッドコードだった |
| 3 | `lib/line_music/client.rb` が `interval: 30, interval_randomness: 0, backoff_factor: 1` | 最大約90秒のジッタなし同期スリープ。`Parallel(in_processes: 4)` と併用で thundering herd |
| 4 | `retry_statuses` 未指定 | **429 がリトライされず `Retry-After` も無視されていた**（下記の調査参照） |
| 5 | apple_music の `Authorization` ヘッダがメモ化コネクションに焼き付き | 24時間の JWT が長時間プロセスで更新されない |
| 6 | apple_music が**毎リクエスト ES256 署名を実行** | 無駄なCPU消費 |
| 7 | `lib/tasks/touhou_music_discover.rake` の素の `Faraday.get` | タイムアウトもリトライもなし |

## 実装

### `lib/external_api/connection.rb`（新規）

`ExternalApi::Connection.build(service, url:, adapter:, &block)` がプロファイルを適用した `Faraday::Connection` を返します。呼び出し側ブロックはリトライ設定の**後**・アダプタ設定の**前**に評価されるため、ブロックで何を追加してもアダプタが必ずハンドラスタックの末尾に来ます（Faraday の要求）。

| service | open_timeout | timeout | retry max | interval | backoff | max_interval | randomness | methods |
|---|---|---|---|---|---|---|---|---|
| `:yt_music` | 5 | 15 | 3 | 0.5 | 2 | 10 | 0.3 | `get post` |
| `:line_music` | 5 | 10 | 3 | 1.0 | 2 | 15 | 0.5 | `get post` |
| `:apple_music` | 5 | 15 | 3 | 1.0 | 2 | 20 | 0.5 | `get post` |
| `:github` | 5 | 30 | 2 | 1.0 | 2 | 10 | 0.5 | `get` |

共通: `retry_statuses: [429, 500, 502, 503, 504]`、例外は `Faraday::ConnectionFailed` / `SSLError` / `TimeoutError` / `Net::OpenTimeout` / `Net::ReadTimeout` / `Errno::ECONNRESET` / `Errno::EHOSTUNREACH`。

`:post` をリトライ対象に含めていますが、対象APIの POST はいずれも参照系（検索・取得）で再送しても副作用がありません。

### インストール済み gem のソースを読んで確認したこと

- **faraday-retry 2.4.0**: `Retry-After` が尊重されるのは `retry_statuses` 経由のみ。レスポンスのステータスが `retry_statuses` に含まれる場合だけ `Faraday::RetriableResponse` が送出され、待機時間計算のコードパスに入る。**未指定だと 429 は素通りする**
- **faraday 2.14.3 `Faraday::Request::Authorization`**: `on_request` がリクエスト毎に走り、arity 0 の Proc をその都度呼ぶ。`-> { config.authentication_token }` は毎回再評価されるため JWT が常に最新になる

### Apple Music の JWT

`lib/apple_music/config.rb` の `authentication_token` に有効期限付きメモ化を追加しました（`TOKEN_TTL = 12.hours` / `REFRESH_MARGIN = 10.minutes`）。`AppleMusic.config` は `config/initializers/apple_music.rb` で単一インスタンスに固定され `Parallel(in_threads: 3)` から共有されうるため、判定と再生成を `Mutex` で排他制御しています。

TTL は従来の24時間から12時間に短縮しました（Apple の上限は6か月ですが短命の方が安全）。

## `app/services/spotify_web_api/client.rb` について

excon ベースのため `ExternalApi::Connection` の対象外です。当初 `connect_timeout: 5` の追加を検討しましたが、**`spotify-client 1.1.2` のソースを確認したところ `Client#initialize` が読むのは `:access_token, :raise_errors, :retries, :read_timeout, :write_timeout, :app_mode, :persistent` のみで、`connect_timeout` を内部の `Excon.new` に渡していません**。追加しても無言の no-op になるため変更していません。

Spotify の excon クライアントに接続タイムアウトが無いこと自体は実在するギャップですが、解消には rspotify → spotify-client 移行（別Issue）が前提になります。

## 触っていないもの

`lib/yt_music/client.rb` の `parse_cookie_header` — Ruby 4.0 で `cgi/cookie` が削除されたことへの意図的な対応のため、そのまま維持しています。

## テスト

21件追加しました（116 → 137 runs）。

- `test/lib/external_api/connection_test.rb` — プロファイル適用、未定義サービスでの例外、アダプタが必ず末尾に来ること
- `test/lib/apple_music/config_test.rb` — トークンのメモ化、リフレッシュマージンを跨いだ際の再発行
- `test/lib/line_music/client_test.rb` / `test/lib/yt_music/client_test.rb` — タイムアウト値とリトライミドルウェアの適用

## 検証

実クライアントの設定値を runner で実測しました。

```
yt_music     open=5 read=15 handlers=Middleware,Logger,Json
line_music   open=5 read=10 handlers=Middleware,Logger,Json,Json
apple_music  open=5 read=15 handlers=Middleware,Logger,Json,Json,Authorization
github       open=5 read=30
```

- `CI=true RAILS_ENV=test bin/rails test` → 137 runs, 1030 assertions, 0 failures, 0 errors, 0 skips
- `RAILS_ENV=test bin/rails zeitwerk:check` → All is good!
- `RAILS_ENV=production SECRET_KEY_BASE=dummy bin/rails zeitwerk:check` → All is good!
- `bundle exec rubocop --parallel` → 212 files inspected, no offenses detected

実際の外部APIは呼び出していません。

## マージ後に確認したいこと

`line_music` の待機時間を 30秒固定から 1→2→4秒（ジッタ付き・上限15秒）に短縮しています。LINE MUSIC は非公式APIでレート制限が不明なため、`line_music:search_albums_and_save` を一度実データで流して 429/5xx の発生率を確認し、必要なら `interval` / `max_interval` を上げる想定です。