### PR TITLE
Spotifyのリトライ処理を共通ヘルパーに集約し指数バックオフとRetry-Afterに対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem 'ostruct'
 gem 'pagy'
 gem 'parallel'
 gem 'redis'
-gem 'retryable'
 gem 'rspotify'
 gem 'spotify-client', require: 'spotify/client'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,6 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    retryable (3.0.5)
     rspotify (2.12.4)
       addressable (~> 2.8.0)
       omniauth-oauth2 (>= 1.6)
@@ -416,7 +415,6 @@ DEPENDENCIES
   puma (~> 8.0)
   rails (~> 8.1.0)
   redis
-  retryable
   rspotify
   rubocop
   rubocop-performance

--- a/app/models/admin/actions.rb
+++ b/app/models/admin/actions.rb
@@ -666,8 +666,8 @@ module Admin
         max_count = SpotifyTrack.count
         inform "Spotify 楽曲: #{count}/#{max_count} Progress: #{progress_percent(count, max_count)}%"
         SpotifyTrack.eager_load(:album, :spotify_album, :track).find_in_batches(batch_size: 100) do |spotify_tracks|
-          Retryable.retryable(tries: 5, sleep: 15, on: [RestClient::TooManyRequests, RestClient::InternalServerError]) do |retries, exception|
-            warn "try #{retries} failed with exception: #{exception}" if retries.positive?
+          SpotifyRetry.with_retry(source: 'Admin::Actions::FetchSpotifyAudioFeatures') do |attempt, exception|
+            warn "try #{attempt} failed with exception: #{exception}" if attempt.positive?
 
             SpotifyClient::AudioFeatures.fetch_by_spotify_tracks(spotify_tracks)
           end
@@ -707,8 +707,8 @@ module Admin
           inform "Spotify オーディオ特性取得中: #{batch.first&.album&.spotify_album_name || batch.first&.spotify_album&.name || 'アルバム名未取得'} / " \
                  "#{batch.first(3).map { |spotify_track| spotify_track_display_name(spotify_track) }.join(', ')}"
           begin
-            Retryable.retryable(tries: 5, sleep: 15, on: [RestClient::TooManyRequests, RestClient::InternalServerError]) do |retries, exception|
-              warn "try #{retries} failed with exception: #{exception}" if retries.positive?
+            SpotifyRetry.with_retry(source: 'Admin::Actions::FetchMissingSpotifyAudioFeatures') do |attempt, exception|
+              warn "try #{attempt} failed with exception: #{exception}" if attempt.positive?
 
               SpotifyClient::AudioFeatures.fetch_by_spotify_tracks(batch)
             end
@@ -1155,8 +1155,8 @@ module Admin
         count = 0
         max_count = SpotifyAlbum.count
         SpotifyAlbum.eager_load(:album).find_in_batches(batch_size: 20) do |spotify_albums|
-          Retryable.retryable(tries: 5, sleep: 15, on: [RestClient::TooManyRequests, RestClient::InternalServerError]) do |retries, exception|
-            warn "try #{retries} failed with exception: #{exception}" if retries.positive?
+          SpotifyRetry.with_retry(source: 'Admin::Actions::UpdateSpotifyAlbum') do |attempt, exception|
+            warn "try #{attempt} failed with exception: #{exception}" if attempt.positive?
 
             SpotifyClient::Album.update_albums(spotify_albums)
           end
@@ -1176,8 +1176,8 @@ module Admin
         count = 0
         max_count = SpotifyTrack.count
         SpotifyTrack.eager_load(:album, :spotify_album, :track).find_in_batches(batch_size: 50) do |spotify_tracks|
-          Retryable.retryable(tries: 5, sleep: 15, on: [RestClient::TooManyRequests, RestClient::InternalServerError]) do |retries, exception|
-            warn "try #{retries} failed with exception: #{exception}" if retries.positive?
+          SpotifyRetry.with_retry(source: 'Admin::Actions::UpdateSpotifyTrack') do |attempt, exception|
+            warn "try #{attempt} failed with exception: #{exception}" if attempt.positive?
 
             SpotifyClient::Track.update_tracks(spotify_tracks)
           end

--- a/app/models/spotify_client/album.rb
+++ b/app/models/spotify_client/album.rb
@@ -28,30 +28,23 @@ module SpotifyClient
         )
       end
 
+      # NOTE: このブロックは Parallel の子プロセス内で実行される。そのため
+      # SpotifyRetry.with_retry 内の SpotifyRateLimit.record! は子プロセスの Rails.cache に書き込まれる。
+      # 本番環境 (Redis) では親プロセスと共有されるが、開発環境 (memory_store) では共有されない。
+      # これは元々の挙動と同じであり、今回の変更によるリグレッションではない。
       Parallel.each(years, in_processes: 3, finish: finish_callback) do |year|
         keyword = "#{KEYWORD} year:#{year}"
-        retry_count = 0
-        max_retries = 5
-        begin
+        # 全カタログ取得の処理であり、年単位でスキップするとアルバムが欠落してしまうため、
+        # デフォルト(tries: 5)より大きいリトライ回数を明示的に指定する。
+        # ただし旧実装(429を無限リトライしていた)と異なり上限は設けてあり、
+        # 1回あたりの待機時間も SpotifyRetry の max_retry_after (900秒) で頭打ちになる。
+        SpotifyRetry.with_retry(source: 'SpotifyClient::Album.fetch_touhou_albums', tries: 10) do |attempt, exception|
+          puts "Retrying year:#{year} (attempt #{attempt}) after #{exception.class}: #{exception.message}" if attempt.positive?
+
           search_and_save_albums(keyword, year)
-        rescue RestClient::TooManyRequests => e
-          retry_after = retry_after_seconds(e) || 30
-          SpotifyRateLimit.record!(retry_after:, source: 'SpotifyClient::Album.fetch_touhou_albums')
-          puts "Rate limit exceeded for year:#{year}. Waiting for #{retry_after} seconds..."
-          sleep retry_after
-          retry
-        rescue RestClient::Exceptions::OpenTimeout, RestClient::Exceptions::ReadTimeout, Net::OpenTimeout => e
-          retry_count += 1
-          if retry_count <= max_retries
-            wait_time = 2**retry_count # 指数バックオフ: 2, 4, 8, 16, 32秒
-            puts "Connection timeout for year:#{year}. Retrying in #{wait_time} seconds... (#{retry_count}/#{max_retries})"
-            puts "Error: #{e.message}"
-            sleep wait_time
-            retry
-          else
-            puts "Max retries reached for year:#{year}. Skipping..."
-          end
         end
+      rescue StandardError => e
+        puts "Max retries reached for year:#{year}. Skipping... (#{e.class}: #{e.message})"
       end
     end
 
@@ -226,20 +219,8 @@ module SpotifyClient
     end
     private_class_method :search_and_save_album_by_jan
 
-    def self.with_spotify_retry(max_retry_after:, max_attempts: 3)
-      attempts = 0
-
-      begin
-        yield
-      rescue RestClient::TooManyRequests => e
-        attempts += 1
-        retry_after = retry_after_seconds(e)
-        SpotifyRateLimit.record!(retry_after:, source: 'SpotifyClient::Album.with_spotify_retry')
-        raise if retry_after.blank? || retry_after > max_retry_after || attempts >= max_attempts
-
-        sleep retry_after
-        retry
-      end
+    def self.with_spotify_retry(max_retry_after:, max_attempts: 3, &)
+      SpotifyRetry.with_retry(source: 'SpotifyClient::Album.with_spotify_retry', tries: max_attempts, max_retry_after:, &)
     end
     private_class_method :with_spotify_retry
 

--- a/app/models/spotify_retry.rb
+++ b/app/models/spotify_retry.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Spotify API 呼び出しの共通リトライ処理。
+#
+# - 429 (Too Many Requests) は Spotify が返す `Retry-After` ヘッダーに従って待機する
+# - 一時的なサーバーエラー・タイムアウト系は指数バックオフ + ジッターで再試行する
+#
+# ブロックの呼び出しシグネチャは旧 retryable gem の retryable メソッドと互換にしてあるため、
+# 既存の呼び出し箇所をほぼそのまま置き換えられる:
+#
+#   SpotifyRetry.with_retry(source: 'Admin::Actions::FetchSpotifyAudioFeatures') do |attempt, exception|
+#     warn "try #{attempt} failed with exception: #{exception}" if attempt.positive?
+#     # ... work ...
+#   end
+class SpotifyRetry
+  DEFAULT_TRIES = 5
+  DEFAULT_RETRY_AFTER = 30
+  # Spotify がまれに非常に長い Retry-After (数時間単位) を返すことがあるため、
+  # この秒数を超える場合は待たずに例外を再送出し、呼び出し元で処理を打ち切れるようにする
+  DEFAULT_MAX_RETRY_AFTER = 900
+
+  # 一時的なサーバーエラー・タイムアウト系の指数バックオフ設定
+  BASE_SLEEP = 5
+  MAX_SLEEP = 120
+  JITTER = 0.3
+
+  DEFAULT_SLEEPER = ->(seconds) { Kernel.sleep(seconds) }
+
+  # 429 (レート制限)。Retry-After ヘッダーに従って待機する
+  RATE_LIMIT_ERROR = RestClient::TooManyRequests
+
+  # 一時的なサーバーエラー・タイムアウト系。指数バックオフ + ジッターで再試行する
+  TRANSIENT_ERRORS = [
+    RestClient::InternalServerError,
+    RestClient::BadGateway,
+    RestClient::ServiceUnavailable,
+    RestClient::GatewayTimeout,
+    RestClient::Exceptions::OpenTimeout,
+    RestClient::Exceptions::ReadTimeout,
+    Net::OpenTimeout,
+    Net::ReadTimeout
+  ].freeze
+
+  class << self
+    # @param source [String] SpotifyRateLimit に記録する呼び出し元の名前（管理画面バナーに表示される）
+    # @param tries [Integer] 最大試行回数
+    # @param max_retry_after [Integer] この秒数を超える Retry-After を受け取ったら待機せず再送出する
+    # @param sleeper [#call] 実際の待機処理。テストでは差し替えて実際にはスリープさせない
+    # @yieldparam attempt [Integer] 試行回数。初回は 0（旧 retryable gem と同じ挙動）
+    # @yieldparam exception [Exception, nil] 直前の失敗の例外。初回は nil
+    def with_retry(source:, tries: DEFAULT_TRIES, max_retry_after: DEFAULT_MAX_RETRY_AFTER, sleeper: DEFAULT_SLEEPER)
+      attempt = 0
+      exception = nil
+
+      loop do
+        return yield(attempt, exception)
+      rescue RATE_LIMIT_ERROR => e
+        attempt += 1
+        exception = e
+        sleeper.call(rate_limit_delay(e, source:, tries:, attempt:, max_retry_after:))
+      rescue *TRANSIENT_ERRORS => e
+        attempt += 1
+        exception = e
+        raise if attempt >= tries
+
+        sleeper.call(transient_delay(attempt))
+      end
+    end
+
+    private
+
+    def rate_limit_delay(error, source:, tries:, attempt:, max_retry_after:)
+      retry_after = SpotifyRateLimit.retry_after_seconds(error) || DEFAULT_RETRY_AFTER
+      # 管理画面のバナーに反映するため、待機するかどうかに関わらず必ず記録する
+      SpotifyRateLimit.record!(retry_after:, source:)
+
+      raise error if retry_after > max_retry_after
+      raise error if attempt >= tries
+
+      retry_after
+    end
+
+    def transient_delay(attempt)
+      base_delay = [BASE_SLEEP * (2**(attempt - 1)), MAX_SLEEP].min
+      # 複数プロセス・スレッドが同時にリトライして再びサーバーに負荷が集中する
+      # (thundering herd) のを避けるため、ジッターを加えてリトライ間隔を分散させる
+      base_delay * (1 + (rand * JITTER))
+    end
+  end
+end

--- a/lib/tasks/spotify.rake
+++ b/lib/tasks/spotify.rake
@@ -287,8 +287,8 @@ namespace :spotify do
     max_count = SpotifyTrack.count
     print "\rSpotify 楽曲: #{count}/#{max_count} Progress: #{(count * 100.0 / max_count).round(1)}%"
     SpotifyTrack.eager_load(:album, :spotify_album, :track).find_in_batches(batch_size: 100) do |spotify_tracks|
-      Retryable.retryable(tries: 5, sleep: 15, on: [RestClient::TooManyRequests, RestClient::InternalServerError]) do |retries, exception|
-        puts "try #{retries} failed with exception: #{exception}" if retries.positive?
+      SpotifyRetry.with_retry(source: 'spotify:fetch_audio_features') do |attempt, exception|
+        puts "try #{attempt} failed with exception: #{exception}" if attempt.positive?
 
         SpotifyClient::AudioFeatures.fetch_by_spotify_tracks(spotify_tracks)
       end
@@ -304,8 +304,8 @@ namespace :spotify do
     count = 0
     max_count = SpotifyAlbum.count
     SpotifyAlbum.eager_load(:album).find_in_batches(batch_size: 20) do |spotify_albums|
-      Retryable.retryable(tries: 5, sleep: 15, on: [RestClient::TooManyRequests, RestClient::InternalServerError]) do |retries, exception|
-        puts "try #{retries} failed with exception: #{exception}" if retries.positive?
+      SpotifyRetry.with_retry(source: 'spotify:update_spotify_albums') do |attempt, exception|
+        puts "try #{attempt} failed with exception: #{exception}" if attempt.positive?
 
         SpotifyClient::Album.update_albums(spotify_albums)
       end
@@ -320,8 +320,8 @@ namespace :spotify do
     count = 0
     max_count = SpotifyTrack.count
     SpotifyTrack.eager_load(:album, :spotify_album, :track).find_in_batches(batch_size: 50) do |spotify_tracks|
-      Retryable.retryable(tries: 5, sleep: 15, on: [RestClient::TooManyRequests, RestClient::InternalServerError]) do |retries, exception|
-        puts "try #{retries} failed with exception: #{exception}" if retries.positive?
+      SpotifyRetry.with_retry(source: 'spotify:update_spotify_tracks') do |attempt, exception|
+        puts "try #{attempt} failed with exception: #{exception}" if attempt.positive?
 
         SpotifyClient::Track.update_tracks(spotify_tracks)
       end

--- a/test/models/spotify_retry_test.rb
+++ b/test/models/spotify_retry_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SpotifyRetryTest < ActiveSupport::TestCase
+  test '429 with a Retry-After header sleeps for that duration then succeeds' do
+    error = too_many_requests(retry_after: 3)
+    sleeps = []
+    attempts = 0
+
+    result = with_spotify_rate_limit_cache(ActiveSupport::Cache::MemoryStore.new) do
+      SpotifyRetry.with_retry(source: 'test', sleeper: recording_sleeper(sleeps)) do |attempt, _exception|
+        attempts += 1
+        raise error if attempt.zero?
+
+        :ok
+      end
+    end
+
+    assert_equal :ok, result
+    assert_equal [3], sleeps
+    assert_equal 2, attempts
+  end
+
+  test '429 with Retry-After above max_retry_after re-raises immediately without sleeping' do
+    error = too_many_requests(retry_after: 1_000)
+    sleeps = []
+
+    with_spotify_rate_limit_cache(ActiveSupport::Cache::MemoryStore.new) do
+      assert_raises(RestClient::TooManyRequests) do
+        SpotifyRetry.with_retry(source: 'test', max_retry_after: 900, sleeper: recording_sleeper(sleeps)) { raise error }
+      end
+    end
+
+    assert_empty sleeps
+  end
+
+  test '429 without a Retry-After header falls back to DEFAULT_RETRY_AFTER' do
+    error = too_many_requests(retry_after: nil)
+    sleeps = []
+    attempts = 0
+
+    with_spotify_rate_limit_cache(ActiveSupport::Cache::MemoryStore.new) do
+      SpotifyRetry.with_retry(source: 'test', sleeper: recording_sleeper(sleeps)) do |attempt, _exception|
+        attempts += 1
+        raise error if attempt.zero?
+
+        :ok
+      end
+    end
+
+    assert_equal [SpotifyRetry::DEFAULT_RETRY_AFTER], sleeps
+  end
+
+  test 'transient server errors back off exponentially within the jitter band' do
+    sleeps = []
+
+    assert_raises(RestClient::InternalServerError) do
+      SpotifyRetry.with_retry(source: 'test', tries: 4, sleeper: recording_sleeper(sleeps)) do |_attempt, _exception|
+        raise RestClient::InternalServerError
+      end
+    end
+
+    expected_bases = [5, 10, 20]
+    assert_equal expected_bases.size, sleeps.size
+
+    sleeps.each_with_index do |delay, index|
+      base = expected_bases[index]
+      assert_operator delay, :>=, base
+      assert_operator delay, :<=, base * (1 + SpotifyRetry::JITTER)
+    end
+  end
+
+  test 're-raises the original exception once tries are exhausted' do
+    error = RestClient::InternalServerError.new
+
+    raised = assert_raises(RestClient::InternalServerError) do
+      SpotifyRetry.with_retry(source: 'test', tries: 2, sleeper: recording_sleeper([])) { raise error }
+    end
+
+    assert_same error, raised
+  end
+
+  test 'records the Spotify rate limit status via SpotifyRateLimit on 429' do
+    error = too_many_requests(retry_after: 5)
+    attempts = 0
+
+    with_spotify_rate_limit_cache(ActiveSupport::Cache::MemoryStore.new) do
+      SpotifyRetry.with_retry(source: 'spec-source', sleeper: recording_sleeper([])) do |attempt, _exception|
+        attempts += 1
+        raise error if attempt.zero?
+
+        :ok
+      end
+
+      status = SpotifyRateLimit.current
+      assert_equal 5, status.retry_after
+      assert_equal 'spec-source', status.source
+    end
+  end
+
+  test 'yields attempt starting at 0 on the first try and the previous exception thereafter' do
+    error = RestClient::InternalServerError.new
+    observed = []
+
+    SpotifyRetry.with_retry(source: 'test', sleeper: recording_sleeper([])) do |attempt, exception|
+      observed << [attempt, exception]
+      raise error if attempt.zero?
+
+      :ok
+    end
+
+    assert_equal [0, nil], observed[0]
+    assert_equal 1, observed[1][0]
+    assert_same error, observed[1][1]
+  end
+
+  private
+
+  # `sleeper:` に注入し、実際にスリープさせずに要求された待機秒数だけを記録する
+  def recording_sleeper(sleeps)
+    ->(seconds) { sleeps << seconds }
+  end
+
+  def too_many_requests(retry_after:)
+    headers = retry_after.nil? ? {} : { retry_after: retry_after.to_s }
+    response = Struct.new(:headers).new(headers)
+    RestClient::TooManyRequests.new(response)
+  end
+
+  def with_spotify_rate_limit_cache(cache)
+    SpotifyRateLimit.cache_store = cache
+    yield
+  ensure
+    SpotifyRateLimit.cache_store = nil
+  end
+end


### PR DESCRIPTION
## 概要

Spotify API 呼び出しのリトライ処理が**9箇所に重複**しており、いずれも固定15秒スリープで指数バックオフもジッターもなく、**Spotify が `Retry-After` ヘッダーで指示する待機時間も無視**していました。`SpotifyRetry` に集約します。

## 置き換えた9箇所

`Retryable.retryable(tries: 5, sleep: 15, on: [...])` が7箇所:

| ファイル | 行 | 呼び出し元 |
|---|---|---|
| `app/models/admin/actions.rb` | 669 | `FetchSpotifyAudioFeatures#handle` |
| `app/models/admin/actions.rb` | 710 | `FetchMissingSpotifyAudioFeatures#handle` |
| `app/models/admin/actions.rb` | 1158 | `UpdateSpotifyAlbum#handle` |
| `app/models/admin/actions.rb` | 1179 | `UpdateSpotifyTrack#handle` |
| `lib/tasks/spotify.rake` | 290 | `spotify:fetch_audio_features` |
| `lib/tasks/spotify.rake` | 307 | `spotify:update_spotify_albums` |
| `lib/tasks/spotify.rake` | 323 | `spotify:update_spotify_tracks` |

自前実装が2箇所（`app/models/spotify_client/album.rb`）:
- `with_spotify_retry` private class method
- `fetch_touhou_albums` の `Parallel.each` 内の `begin/rescue/retry`

## `SpotifyRetry`（`app/models/spotify_retry.rb`）

配置は既存の `app/models/spotify_rate_limit.rb` の隣です。同じ責務領域（Spotify のレート制限状態）で、既に `Admin::Actions` / `SpotifyClient::*` / `Admin::BaseController` から参照されています。

ブロックのシグネチャを `Retryable.retryable` と互換にしたため、呼び出し箇所はほぼ1:1の置換で済んでいます。**インストール済みの `retryable-3.0.5` のソースを読んで確認**したところ `return yield retries, retry_exception` で、初回は `retries = 0` / `retry_exception = nil` でした。`SpotifyRetry` もこれを再現しています。

### 429（レート制限）
- `SpotifyRateLimit.retry_after_seconds(e)` で `Retry-After` を取得（無ければ `DEFAULT_RETRY_AFTER = 30`）
- 待機するかどうかに関わらず `SpotifyRateLimit.record!` を呼び、管理画面のバナー（`app/views/layouts/admin.html.erb:108`）に反映
- `max_retry_after`（既定900秒）を超える `Retry-After` は**待たずに再送出**（何時間も寝ないため）

### 一時的なサーバーエラー / タイムアウト
`RestClient::InternalServerError` / `BadGateway` / `ServiceUnavailable` / `GatewayTimeout` / `Exceptions::OpenTimeout` / `Exceptions::ReadTimeout` / `Net::OpenTimeout` / `Net::ReadTimeout`

指数バックオフ + ジッター: 5 / 10 / 20 / 40秒（各 +0〜30%）。従来の固定15秒×4回より初回復帰が速く、長期障害には粘ります。

> 上記の RestClient 例外クラスが古い rest-client 2.0.2 に実在することを、インストール済み gem を実際にロードして確認済みです（rest-client は `STATUSES` から HTTP ステータスごとに例外クラスを動的生成しています）。

### テスト容易性
`sleeper:` を注入可能にしてあり（既定 `->(s) { Kernel.sleep(s) }`）、テストは実際にスリープしません。

## 挙動の変更点（レビュー時にご確認ください）

### 1. `fetch_touhou_albums` の429が無限リトライから上限付きに
旧実装は 429 に対して `sleep retry_after; retry` を**上限なし**で回しており、レート制限が続くとジョブが終わらない状態でした。

一方で単純に既定の `tries: 5` にすると、レート制限が続いた年のアルバムが黙ってスキップされ**カタログが欠落**します。カタログはこのプロジェクトの主要資産なので、この呼び出し箇所だけ **`tries: 10` を明示指定**しました。上限は付きつつ、実運用でスキップに至ることはまず無い水準です（1回あたりの待機も `max_retry_after` 900秒で頭打ち）。

### 2. `with_spotify_retry` が `Retry-After` 無しでも再試行するように
旧実装は `retry_after.blank?` のとき即座に再送出していましたが、`DEFAULT_RETRY_AFTER = 30` にフォールバックして再試行するようになりました。より粘り強くなる方向の変更です。

## `Parallel` 子プロセスでのキャッシュについて

`fetch_touhou_albums` の `Parallel.each` ブロック内で呼ばれる `SpotifyRateLimit.record!` は、**子プロセスの `Rails.cache`** に書き込まれます。本番（Redis）では親と共有されますが、開発（`memory_store`）では共有されません。**これは元々の挙動と同一でリグレッションではありません**が、コード上にコメントとして明記しました。

## 対象外としたもの

- `search_and_save_albums` 内の `loop...rescue...retry`（ページネーション制御）と `process_album` の `rescue` — 今回のスコープ外
- `Admin::Actions::UpdateLineMusicTrack#with_retry`（`actions.rb:1133`）— LINE MUSIC 用で Spotify とは無関係

## `retryable` gem の削除

全置換後、`grep -rn 'Retryable' --include='*.rb' --include='*.rake' app lib config test` が**0件**であることを確認してから `Gemfile` / `Gemfile.lock` から削除しました。他 gem のバージョンは動いていません。

## テスト

`test/models/spotify_retry_test.rb` を7件追加（137 → 144 runs）。

1. `Retry-After: 3` の429 → 3秒の待機を要求して成功
2. `Retry-After` が `max_retry_after` 超 → 待機せず即再送出
3. `Retry-After` 無しの429 → `DEFAULT_RETRY_AFTER` を使用
4. 一時的な500 → 5/10/20 の指数列（ジッター範囲内）
5. `tries` 到達 → 元の例外オブジェクトを再送出
6. 429時に `SpotifyRateLimit.record!` が呼ばれる
7. ブロックが `(attempt, exception)` を受け取り初回は `(0, nil)`

## 検証

- `CI=true RAILS_ENV=test bin/rails test` → 144 runs, 1058 assertions, 0 failures, 0 errors, 0 skips
- `RAILS_ENV=production SECRET_KEY_BASE=dummy bin/rails zeitwerk:check` → All is good!
- `bundle exec rubocop --parallel` → 214 files inspected, no offenses detected

実際の Spotify API は呼び出していません。