### PR TITLE
起動時のSpotify認証とRedisキャッシュストア設定を堅牢化

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,14 +38,37 @@ module TouhouMusicDiscover
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # Spotify認証設定
-    RSpotify.authenticate(ENV.fetch('SPOTIFY_CLIENT_ID', nil), ENV.fetch('SPOTIFY_CLIENT_SECRET', nil)) if ENV.fetch('SPOTIFY_CLIENT_ID', nil) && ENV.fetch('SPOTIFY_CLIENT_SECRET', nil)
-
     # Redis cache store設定 (Rails 8対応)
+    #
+    # 開発環境は :memory_store（config/environments/development.rb）、
+    # テスト環境は :null_store（config/environments/test.rb）で上書きされるため、
+    # 以下の redis_cache_store 設定は実質的に本番環境（および明示的に上書きしていない環境）でのみ有効。
+    #
+    # - REDIS_URL 未設定時に URL が "/0" に縮退してしまう不具合を修正するため、
+    #   デフォルト値 'redis://localhost:6379' を明示。
+    # - REDIS_URL 末尾にスラッシュが付く場合（例: docker-compose.yml の
+    #   REDIS_URL=redis://redis:6379/）に "//0" と二重スラッシュになる不具合を
+    #   .chomp('/') で修正。
+    # - pool を追加し、PumaのスレッドプールサイズにあわせてRedis接続を並列化
+    #   （未設定だとRedisアクセスがPumaのスレッド数と無関係に直列化されてしまう）。
+    # - connect/read/write の timeout を設定し、Redisがハングした場合に
+    #   リクエストが無期限にブロックされないようにする。
+    # - reconnect_attempts で一時的な接続断からの再接続をリトライする。
+    # - error_handler を追加し、Redis障害時に例外がそのままアプリに伝播するのを防ぎ、
+    #   ログに記録した上でフォールバック動作（returning値）に委ねる
+    #   （従来は Admin::BaseController が独自に rescue していただけだった）。
     config.cache_store = :redis_cache_store, {
-      url: "#{ENV.fetch('REDIS_URL', nil)}/0",
+      url: "#{ENV.fetch('REDIS_URL', 'redis://localhost:6379').chomp('/')}/0",
       namespace: 'cache',
-      expires_in: 90.minutes
+      expires_in: 90.minutes,
+      pool: { size: ENV.fetch('RAILS_MAX_THREADS', 3).to_i, timeout: 5 },
+      connect_timeout: 1,
+      read_timeout: 1,
+      write_timeout: 1,
+      reconnect_attempts: [0.05, 0.1, 0.2],
+      error_handler: lambda { |method:, returning:, exception:|
+        Rails.logger.error("[redis_cache_store] #{method} failed (returning #{returning.inspect}): #{exception.class}: #{exception.message}")
+      }
     }
 
     config.i18n.default_locale = :ja

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,12 +69,11 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [:id]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # DNSリバインディング等のHostヘッダー攻撃対策。
+  # APP_HOST 未設定時は空配列となり Rails はチェック自体をスキップするため、
+  # 設定していない環境でも壊れない。
+  config.hosts = [ENV.fetch('APP_HOST', nil)].compact
+
+  # ヘルスチェックはHost検証の対象外にする
+  config.host_authorization = { exclude: ->(request) { request.path == '/up' } }
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,7 +4,7 @@ require 'omniauth'
 require 'rspotify/oauth'
 
 # OmniAuth 2.0以降のCSRF対策設定
-OmniAuth.config.allowed_request_methods = %i[post get]
+OmniAuth.config.allowed_request_methods = %i[post]
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :spotify, ENV.fetch('SPOTIFY_CLIENT_ID', nil), ENV.fetch('SPOTIFY_CLIENT_SECRET', nil), scope: 'user-read-email playlist-modify-public user-library-read user-library-modify'

--- a/config/initializers/rspotify.rb
+++ b/config/initializers/rspotify.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# RSpotify のクライアントクレデンシャル認証。
+#
+# Application クラス本体で実行するとタイムアウトの無いネットワークI/Oが
+# 起動時に走り、Spotify 側の障害時に bin/rails のあらゆるコマンドが
+# 起動できなくなるため、after_initialize に移している。
+Rails.application.config.after_initialize do
+  next if Rails.env.test?
+
+  client_id = ENV.fetch('SPOTIFY_CLIENT_ID', nil)
+  client_secret = ENV.fetch('SPOTIFY_CLIENT_SECRET', nil)
+  next if client_id.blank? || client_secret.blank?
+
+  begin
+    RSpotify.authenticate(client_id, client_secret)
+  rescue StandardError => e
+    Rails.logger.error("[rspotify] client credentials authentication failed: #{e.class}: #{e.message}")
+  end
+end


### PR DESCRIPTION
## 概要

起動時のネットワークI/OとRedisキャッシュストアの設定に、実害のある問題が複数あったため修正します。

## 1. `RSpotify.authenticate` を起動パスから外す

`config/application.rb` の `class Application < Rails::Application` の**本体**で以下が実行されていました。

```ruby
RSpotify.authenticate(ENV.fetch('SPOTIFY_CLIENT_ID', nil), ENV.fetch('SPOTIFY_CLIENT_SECRET', nil)) if ...
```

これは**タイムアウトの無いネットワークI/Oがクラス本体の評価時に走る**ということで、Spotify 側が落ちている・遅い場合に `bin/rails console` / `runner` / `rake`、極端には `bin/rails -h` すら起動できなくなります。

`config/initializers/rspotify.rb` を新設し `after_initialize` へ移設しました。

- `Rails.env.test?` ではスキップ
- 資格情報が未設定ならスキップ
- 例外は `Rails.logger.error` に記録して**起動は落とさない**

移設前に `grep -rn 'RSpotify\.' app config lib` で、起動直後に認証済みであることを前提としたコードが無いことを確認済みです（唯一のヒットは削除した行そのもの）。`config/initializers/omniauth.rb` は `rspotify/oauth` を使いますが、provider にクライアントID/secretを直接渡しており `authenticate` に依存しません。

## 2. Redis キャッシュストアの堅牢化

修正した5つの問題:

| # | 問題 |
|---|---|
| 1 | `REDIS_URL` 未設定時に URL が文字列 `"/0"` に縮退する |
| 2 | **`docker-compose.yml:36` が `REDIS_URL: "redis://redis:6379/"`（末尾スラッシュ）**を渡しており、`redis://redis:6379//0` という二重スラッシュのURLが生成される |
| 3 | `pool` 未指定でRedisアクセスがPumaのスレッド数と無関係に直列化される |
| 4 | `error_handler` 未指定でRedis障害時に例外がアプリまで伝播する（`Admin::BaseController` が独自に rescue していただけ） |
| 5 | タイムアウト未指定でRedisがハングするとリクエストが無期限にブロックされる |

```ruby
url: "#{ENV.fetch('REDIS_URL', 'redis://localhost:6379').chomp('/')}/0",
pool: { size: ENV.fetch('RAILS_MAX_THREADS', 3).to_i, timeout: 5 },
connect_timeout: 1, read_timeout: 1, write_timeout: 1,
reconnect_attempts: [0.05, 0.1, 0.2],
error_handler: lambda { |method:, returning:, exception:| Rails.logger.error(...) }
```

**この設定が効くのは本番のみ**です（開発は `:memory_store`、テストは `:null_store` で上書きされる）。その旨もコード内コメントに明記しました。

### URL生成の実測

```
REDIS_URL='redis://redis:6379/' → redis://redis:6379/0    ← スラッシュ1つ
REDIS_URL 未設定                 → redis://localhost:6379/0
```

## 3. OmniAuth を POST 限定に

`OmniAuth.config.allowed_request_methods` を `%i[post get]` → `%i[post]`。

`auth/spotify` への参照を grep したところ、**`app/views/root/index.html.erb:224` の `button_to ... method: :post` の1箇所のみ**で、GET のリンクは存在しませんでした。`omniauth-rails_csrf_protection` が導入済みなので、POST 限定にすることで CSRF 保護が完成します。

## 4. production で Host 検証を有効化

`config/environments/production.rb` の `config.hosts` / `config.host_authorization` はコメントアウトされたままで、DNSリバインディング対策が無効でした。

```ruby
config.hosts = [ENV.fetch('APP_HOST', nil)].compact
config.host_authorization = { exclude: ->(request) { request.path == '/up' } }
```

**`config.hosts` が空配列の場合 Rails はチェック自体をスキップする**ため、`APP_HOST` を設定していない環境でも壊れません（逆に言えば設定するまで防御にはなりません）。ヘルスチェック `/up` は検証対象外にしています。

実測: `APP_HOST` 未設定 → `[]`、`APP_HOST=example.com` → `["example.com"]`

> README に環境変数の専用セクションが無かったため、`APP_HOST` のドキュメント追記は見送りました。

## 触っていないもの

`config/initializers/content_security_policy.rb` — CSP の有効化は `report_only` での観測期間が必要なため別Issueで扱います。

## 検証

- `SPOTIFY_CLIENT_ID= SPOTIFY_CLIENT_SECRET= bin/rails runner` → `BOOT_OK`（資格情報なしで起動できる）
- cache_store URL: 上記の実測どおり
- `config.hosts`: 上記の実測どおり
- `CI=true RAILS_ENV=test bin/rails test` → 144 runs, 1058 assertions, 0 failures, 0 errors, 0 skips
- `RAILS_ENV=production SECRET_KEY_BASE=dummy bin/rails zeitwerk:check` → All is good!
- `bundle exec rubocop --parallel` → 215 files inspected, no offenses detected
- `bundle exec brakeman --no-pager -q -w2` → exit 0

## デプロイ時の推奨

`APP_HOST` を設定するとHost検証が有効になります。未設定のままでも動作しますが、その場合DNSリバインディング対策は効きません。