### PR TITLE
DB/Redisプールとパラレル実行のワーカー数を整合させる

### DIFF
--- a/app/models/admin/actions.rb
+++ b/app/models/admin/actions.rb
@@ -914,7 +914,7 @@ module Admin
         progress = Admin::ActionProgress.current
 
         YtmusicAlbum.find_in_batches(batch_size: 100) do |batch|
-          Parallel.each(batch, in_threads: 3) do |ytmusic_album|
+          ParallelRunner.each(batch, mode: :threads, workers: 3) do |ytmusic_album|
             current_index = nil
             mutex.synchronize do
               processed += 1

--- a/app/models/line_music_album.rb
+++ b/app/models/line_music_album.rb
@@ -150,7 +150,7 @@ class LineMusicAlbum < ApplicationRecord
       end
 
       where(id: ids).then do |records|
-        Parallel.each(records, in_processes: 4, finish: finish_callback) do |line_music_album|
+        ParallelRunner.each(records, workers: :line_music, finish: finish_callback) do |line_music_album|
           with_retry(max_attempts: 3) do
             Rails.logger.info "LINE MUSIC アルバム情報取得: #{line_music_album.line_music_id}"
             lm_album = LineMusic::Album.find(line_music_album.line_music_id)

--- a/app/models/line_music_track.rb
+++ b/app/models/line_music_track.rb
@@ -43,7 +43,7 @@ class LineMusicTrack < ApplicationRecord
       end
 
       Album.includes(:spotify_album, :apple_music_album, :line_music_album).where(id: ids).then do |records|
-        Parallel.each(records, in_processes: 4, finish: finish_callback) do |r|
+        ParallelRunner.each(records, workers: :line_music, finish: finish_callback) do |r|
           process_album(r)
         end
       end

--- a/app/models/parallel_runner.rb
+++ b/app/models/parallel_runner.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Parallel gem の呼び出しを一箇所に集約するラッパー。
+#
+# ワーカー数の決定順序 (優先度の高い順):
+#   1. ParallelRunner.forced_workers  … テスト用のエスケープハッチ。test_helper.rb で 1 に固定し、
+#      全テストを逐次実行・決定的にするために使う。
+#   2. ENV['PARALLEL_WORKERS']        … 実行環境全体での上書き (.githooks/pre-push が 1 を指定)。
+#   3. 呼び出し側の workers: 引数      … 通常はここで WORKERS のキーを指定する。
+# 最終的に [決定値, Parallel.processor_count].min で頭打ちにする。
+#
+# 実行モードは :processes をデフォルトのままにしている。理由は、対象の呼び出し箇所がいずれも
+# 外部API (YtMusic / LineMusic / Spotify の HTTP 呼び出し) 待ちであり、YtMusic::Client や
+# LineMusic::Client のシングルトンが保持するメモ化済み Faraday コネクションが、
+# fork によってプロセスごとに分離されることで結果的にスレッドセーフに保たれているため。
+# :threads に切り替えるとこれらの Faraday コネクションが本当に共有され、安全ではなくなる。
+#
+# ただし残存リスクもある: これらの処理は Solid Queue のワーカースレッドから呼ばれるため、
+# マルチスレッドプロセスからの fork となる。fork の瞬間に他スレッドが握っていたミューテックス
+# (例: Ruby の Logger 内部ミューテックス) は子プロセス側でロックされたまま解放されない可能性があり、
+# これは fork-from-multithreaded-process 一般の既知の危険性で、この設計でも解消しきれていない。
+module ParallelRunner
+  # ワーカー数の単一の情報源。以前は6箇所にハードコードされていた。
+  WORKERS = { ytmusic: 7, line_music: 4, spotify: 3 }.freeze
+
+  MODE_OPTION_KEYS = { processes: :in_processes, threads: :in_threads }.freeze
+
+  class << self
+    # テストからワーカー数を強制するための上書き値 (nil で未設定)
+    attr_accessor :forced_workers
+
+    def each(records, workers:, mode: :processes, finish: nil, &)
+      items = records.to_a
+      count = effective_workers(workers)
+
+      return run_inline(items, finish, &) if count <= 1
+
+      prepare_for_fork if mode == :processes
+      Parallel.each(items, parallel_options(mode, count, finish), &)
+    end
+
+    def reset_forced_workers!
+      self.forced_workers = nil
+    end
+
+    def effective_workers(workers)
+      configured = forced_workers || env_workers || resolve_workers(workers)
+      [configured.to_i, Parallel.processor_count].min
+    end
+
+    private
+
+    def resolve_workers(workers)
+      case workers
+      when Symbol then WORKERS.fetch(workers)
+      when Integer then workers
+      else raise ArgumentError, "workers must be a Symbol in WORKERS or an Integer, got #{workers.inspect}"
+      end
+    end
+
+    def env_workers
+      ENV['PARALLEL_WORKERS'].presence&.to_i
+    end
+
+    def parallel_options(mode, count, finish)
+      option_key = MODE_OPTION_KEYS.fetch(mode) { raise ArgumentError, "unknown mode: #{mode.inspect}" }
+      { option_key => count, finish: }.compact
+    end
+
+    # fork 前に親プロセスのアイドルDBコネクションをプールへ返すための保険。
+    # 子プロセス側は ActiveSupport::ForkTracker がコネクションプールを破棄してくれる
+    # (ActiveRecord の pool_config.rb を参照) ため、これはあくまで親プロセス側の念のための処置。
+    # 対象レコードを materialize した後・fork の直前という、このタイミングでのみ実行すること。
+    # そうしないと処理途中のトランザクションを中断してしまう恐れがある。
+    def prepare_for_fork
+      ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
+    end
+
+    # Parallel gem を経由せず逐次実行する。finish コールバックの引数は
+    # Parallel が渡すもの (item, index, result) と完全に同一にすること。
+    def run_inline(items, finish)
+      items.each_with_index do |item, index|
+        result = yield(item)
+        finish&.call(item, index, result)
+      end
+    end
+  end
+end

--- a/app/models/spotify_client/album.rb
+++ b/app/models/spotify_client/album.rb
@@ -28,11 +28,11 @@ module SpotifyClient
         )
       end
 
-      # NOTE: このブロックは Parallel の子プロセス内で実行される。そのため
+      # NOTE: このブロックは ParallelRunner (Parallel) の子プロセス内で実行される。そのため
       # SpotifyRetry.with_retry 内の SpotifyRateLimit.record! は子プロセスの Rails.cache に書き込まれる。
       # 本番環境 (Redis) では親プロセスと共有されるが、開発環境 (memory_store) では共有されない。
       # これは元々の挙動と同じであり、今回の変更によるリグレッションではない。
-      Parallel.each(years, in_processes: 3, finish: finish_callback) do |year|
+      ParallelRunner.each(years, workers: :spotify, finish: finish_callback) do |year|
         keyword = "#{KEYWORD} year:#{year}"
         # 全カタログ取得の処理であり、年単位でスキップするとアルバムが欠落してしまうため、
         # デフォルト(tries: 5)より大きいリトライ回数を明示的に指定する。

--- a/app/models/ytmusic_album.rb
+++ b/app/models/ytmusic_album.rb
@@ -330,7 +330,7 @@ class YtmusicAlbum < ApplicationRecord
       end
 
       where(id: ids).then do |records|
-        Parallel.each(records, in_processes: 7, finish: finish_callback) do |ytmusic_album|
+        ParallelRunner.each(records, workers: :ytmusic, finish: finish_callback) do |ytmusic_album|
           album = YtMusic::Album.find(ytmusic_album.browse_id)
           url = "https://music.youtube.com/browse/#{ytmusic_album.browse_id}"
           ytmusic_album.update_album(album, url) if album

--- a/app/models/ytmusic_track.rb
+++ b/app/models/ytmusic_track.rb
@@ -39,7 +39,7 @@ class YtmusicTrack < ApplicationRecord
       end
 
       Album.includes(:ytmusic_album, spotify_album: [:spotify_tracks], apple_music_album: [:apple_music_tracks]).where(id: ids).then do |records|
-        Parallel.each(records, in_processes: 7, finish: finish_callback) do |r|
+        ParallelRunner.each(records, workers: :ytmusic, finish: finish_callback) do |r|
           process_album(r)
         end
       end

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,11 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  #
+  # puma.rbのスレッド数とqueue.ymlのスレッド数の大きい方 + 予備2。
+  # 同じ設定をPumaのWebプロセスとSolid Queueのワーカープロセスの双方が使うため、
+  # どちらのプロセスでもコネクションが枯渇しないよう大きい方に合わせる。
+  pool: <%= [ENV.fetch("RAILS_MAX_THREADS", 5).to_i, ENV.fetch("JOB_CONCURRENCY", 1).to_i * 3].max + 2 %>
 
 development:
   primary:

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -29,6 +29,10 @@
 threads_count = ENV.fetch('RAILS_MAX_THREADS', 3)
 threads threads_count, threads_count
 
+# クラスタモード(workers + preload_app!)は採用しない。下記の `plugin :solid_queue` と
+# 併用するとfork後にDB/Redisコネクションを張り直す処理が複数箇所で必要になり、リスクが割に合わない。
+# また本アプリはトラフィックの少ない社内向け管理画面であり、クラスタモードの恩恵も小さい。
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch('PORT', 3000)
 

--- a/lib/redis_pool.rb
+++ b/lib/redis_pool.rb
@@ -22,11 +22,21 @@ class RedisPool
 
     private
 
+    # プールサイズは必ず RAILS_MAX_THREADS 以上にすること。
+    # app/controllers/spotify/playlists_controller.rb が処理の進捗を Redis に
+    # 継続的に書き込んでおり、ここでコネクションが枯渇すると各スレッドが
+    # ConnectionPool::TimeoutError で待たされ、管理画面の進捗表示が停止してしまう。
     def pool
       @pool ||= ConnectionPool.new(
-        size: ENV.fetch('RAILS_MAX_THREADS', 2).to_i,
-        timeout: ENV.fetch('REDIS_TIMEOUT', 1).to_i
-      ) { Redis.new(url: ENV.fetch('REDIS_URL', nil)) }
+        size: ENV.fetch('REDIS_POOL_SIZE') { ENV.fetch('RAILS_MAX_THREADS', 5) }.to_i,
+        timeout: ENV.fetch('REDIS_TIMEOUT', 5).to_f
+      ) do
+        Redis.new(
+          url: ENV.fetch('REDIS_URL', 'redis://localhost:6379'),
+          connect_timeout: 1, read_timeout: 1, write_timeout: 1,
+          reconnect_attempts: [0.05, 0.1, 0.2]
+        )
+      end
     end
   end
 end

--- a/test/models/line_music_album_test.rb
+++ b/test/models/line_music_album_test.rb
@@ -66,13 +66,11 @@ class LineMusicAlbumTest < ActiveSupport::TestCase
     )
     updates = []
 
-    with_parallel_each_running_inline do
-      stub_line_music_album_find(fetched_album) do
-        LineMusicAlbum.unscoped.where(id: line_music_album.id).scoping do
-          LineMusicAlbum.update_line_music_album_info(
-            progress_callback: ->(**attrs) { updates << attrs }
-          )
-        end
+    stub_line_music_album_find(fetched_album) do
+      LineMusicAlbum.unscoped.where(id: line_music_album.id).scoping do
+        LineMusicAlbum.update_line_music_album_info(
+          progress_callback: ->(**attrs) { updates << attrs }
+        )
       end
     end
 
@@ -200,19 +198,5 @@ class LineMusicAlbumTest < ActiveSupport::TestCase
     yield
   ensure
     LineMusic::Album.define_singleton_method(:find, original_method)
-  end
-
-  def with_parallel_each_running_inline
-    original_method = Parallel.method(:each)
-
-    Parallel.define_singleton_method(:each) do |items, options = {}, &block|
-      items.each_with_index do |item, index|
-        result = block.call(item)
-        options[:finish]&.call(item, index, result)
-      end
-    end
-    yield
-  ensure
-    Parallel.define_singleton_method(:each, original_method)
   end
 end

--- a/test/models/line_music_track_test.rb
+++ b/test/models/line_music_track_test.rb
@@ -9,10 +9,8 @@ class LineMusicTrackTest < ActiveSupport::TestCase
     processed_albums = []
 
     with_line_music_track_processor(->(processed_album) { processed_albums << processed_album }) do
-      with_parallel_each_running_inline do
-        Album.unscoped.where(id: album.id).scoping do
-          LineMusicTrack.fetch_tracks(progress_callback: ->(**attrs) { updates << attrs })
-        end
+      Album.unscoped.where(id: album.id).scoping do
+        LineMusicTrack.fetch_tracks(progress_callback: ->(**attrs) { updates << attrs })
       end
     end
 
@@ -36,19 +34,5 @@ class LineMusicTrackTest < ActiveSupport::TestCase
     yield
   ensure
     singleton_class.define_method(:process_album, original_method)
-  end
-
-  def with_parallel_each_running_inline
-    original_method = Parallel.method(:each)
-
-    Parallel.define_singleton_method(:each) do |items, options = {}, &block|
-      items.each_with_index do |item, index|
-        result = block.call(item)
-        options[:finish]&.call(item, index, result)
-      end
-    end
-    yield
-  ensure
-    Parallel.define_singleton_method(:each, original_method)
   end
 end

--- a/test/models/parallel_runner_test.rb
+++ b/test/models/parallel_runner_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ParallelRunnerTest < ActiveSupport::TestCase
+  test 'resolves a Symbol worker key from WORKERS' do
+    with_forced_workers(nil) do
+      with_env('PARALLEL_WORKERS', nil) do
+        assert_equal [7, Parallel.processor_count].min, ParallelRunner.effective_workers(:ytmusic)
+        assert_equal [4, Parallel.processor_count].min, ParallelRunner.effective_workers(:line_music)
+        assert_equal [3, Parallel.processor_count].min, ParallelRunner.effective_workers(:spotify)
+      end
+    end
+  end
+
+  test 'raises for an unknown Symbol worker key' do
+    with_forced_workers(nil) do
+      with_env('PARALLEL_WORKERS', nil) do
+        assert_raises(KeyError) { ParallelRunner.effective_workers(:unknown_platform) }
+      end
+    end
+  end
+
+  test 'resolves an Integer worker count' do
+    with_forced_workers(nil) do
+      with_env('PARALLEL_WORKERS', nil) do
+        assert_equal 2, ParallelRunner.effective_workers(2)
+      end
+    end
+  end
+
+  test 'caps the worker count at the processor count' do
+    with_forced_workers(nil) do
+      with_env('PARALLEL_WORKERS', nil) do
+        assert_equal Parallel.processor_count, ParallelRunner.effective_workers(Parallel.processor_count + 100)
+      end
+    end
+  end
+
+  test 'PARALLEL_WORKERS overrides the per-call workers argument' do
+    with_forced_workers(nil) do
+      with_env('PARALLEL_WORKERS', '4') do
+        assert_equal 4, ParallelRunner.effective_workers(:ytmusic)
+      end
+    end
+  end
+
+  test 'blank PARALLEL_WORKERS is ignored' do
+    with_forced_workers(nil) do
+      with_env('PARALLEL_WORKERS', '') do
+        assert_equal [7, Parallel.processor_count].min, ParallelRunner.effective_workers(:ytmusic)
+      end
+    end
+  end
+
+  test 'forced_workers takes precedence over PARALLEL_WORKERS and the workers argument' do
+    with_forced_workers(2) do
+      with_env('PARALLEL_WORKERS', '4') do
+        assert_equal 2, ParallelRunner.effective_workers(:ytmusic)
+      end
+    end
+  end
+
+  test 'reset_forced_workers! clears the override' do
+    with_forced_workers(3) do
+      ParallelRunner.reset_forced_workers!
+
+      assert_nil ParallelRunner.forced_workers
+    end
+  end
+
+  test 'runs inline without forking when the effective worker count is 1' do
+    visited = []
+
+    # インラインで実行された場合のみ、呼び出し元のローカル変数への追記が見える。
+    # fork していたら子プロセス側の変更は親に反映されない。
+    ParallelRunner.each([1, 2, 3], workers: 1) { |item| visited << item }
+
+    assert_equal [1, 2, 3], visited
+  end
+
+  test 'inline fallback passes item, index and result to the finish callback' do
+    finished = []
+    finish = ->(item, index, result) { finished << [item, index, result] }
+
+    ParallelRunner.each([10, 20], workers: 1, finish:) { |item| item * 2 }
+
+    assert_equal [[10, 0, 20], [20, 1, 40]], finished
+  end
+
+  test 'parallel path passes item, index and result to the finish callback' do
+    mutex = Mutex.new
+    finished = []
+    finish = ->(item, index, result) { mutex.synchronize { finished << [item, index, result] } }
+
+    with_forced_workers(nil) do
+      with_env('PARALLEL_WORKERS', nil) do
+        ParallelRunner.each([10, 20], workers: 2, mode: :threads, finish:) { |item| item * 2 }
+      end
+    end
+
+    assert_equal [[10, 0, 20], [20, 1, 40]], finished.sort
+  end
+
+  test 'raises for an unknown mode' do
+    with_forced_workers(nil) do
+      with_env('PARALLEL_WORKERS', nil) do
+        assert_raises(ArgumentError) do
+          ParallelRunner.each([1, 2], workers: 2, mode: :fibers) { |item| item }
+        end
+      end
+    end
+  end
+
+  private
+
+  def with_forced_workers(value)
+    previous = ParallelRunner.forced_workers
+    ParallelRunner.forced_workers = value
+    yield
+  ensure
+    ParallelRunner.forced_workers = previous
+  end
+
+  def with_env(key, value)
+    previous = ENV.fetch(key, nil)
+    ENV[key] = value
+    yield
+  ensure
+    ENV[key] = previous
+  end
+end

--- a/test/models/spotify_client_album_test.rb
+++ b/test/models/spotify_client_album_test.rb
@@ -100,11 +100,9 @@ module SpotifyClient
       searched_years = []
 
       with_spotify_album_searcher(->(_keyword, year) { searched_years << year }) do
-        with_parallel_each_running_inline do
-          SpotifyClient::Album.fetch_touhou_albums(
-            progress_callback: ->(**attrs) { updates << attrs }
-          )
-        end
+        SpotifyClient::Album.fetch_touhou_albums(
+          progress_callback: ->(**attrs) { updates << attrs }
+        )
       end
 
       years = (2000..Time.zone.today.year).to_a
@@ -196,20 +194,6 @@ module SpotifyClient
       yield
     ensure
       singleton_class.define_method(:search_and_save_albums, original_method)
-    end
-
-    def with_parallel_each_running_inline
-      original_method = Parallel.method(:each)
-
-      Parallel.define_singleton_method(:each) do |items, options = {}, &block|
-        items.each_with_index do |item, index|
-          result = block.call(item)
-          options[:finish]&.call(item, index, result)
-        end
-      end
-      yield
-    ensure
-      Parallel.define_singleton_method(:each, original_method)
     end
   end
 end

--- a/test/models/ytmusic_track_test.rb
+++ b/test/models/ytmusic_track_test.rb
@@ -9,10 +9,8 @@ class YtmusicTrackTest < ActiveSupport::TestCase
     processed_albums = []
 
     with_ytmusic_track_processor(->(processed_album) { processed_albums << processed_album }) do
-      with_parallel_each_running_inline do
-        Album.unscoped.where(id: album.id).scoping do
-          YtmusicTrack.fetch_tracks(progress_callback: ->(**attrs) { updates << attrs })
-        end
+      Album.unscoped.where(id: album.id).scoping do
+        YtmusicTrack.fetch_tracks(progress_callback: ->(**attrs) { updates << attrs })
       end
     end
 
@@ -36,19 +34,5 @@ class YtmusicTrackTest < ActiveSupport::TestCase
     yield
   ensure
     singleton_class.define_method(:process_album, original_method)
-  end
-
-  def with_parallel_each_running_inline
-    original_method = Parallel.method(:each)
-
-    Parallel.define_singleton_method(:each) do |items, options = {}, &block|
-      items.each_with_index do |item, index|
-        result = block.call(item)
-        options[:finish]&.call(item, index, result)
-      end
-    end
-    yield
-  ensure
-    Parallel.define_singleton_method(:each, original_method)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,11 @@ module ActiveSupport
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
 
+    # ParallelRunner を使うコードは、テストでは常に逐次実行 (records.each) にする。
+    # Parallel gem を一切呼ばないため、fork や別スレッドに起因する非決定性がなくなり、
+    # 各テストが同一プロセス・同一トランザクション内で決定的に動作する。
+    ParallelRunner.forced_workers = 1
+
     # Add more helper methods to be used by all tests here...
   end
 end


### PR DESCRIPTION
## 概要

同じ `RAILS_MAX_THREADS` が3箇所で**異なるフォールバック値**を持っており、うち1つは実害のあるバグでした。あわせて6箇所に散在していた `Parallel` の呼び出しを集約します。

計画では別PRだった「テストの Parallel モンキーパッチ解消」も、`ParallelRunner` の直列フォールバックが前提になるため同一PRにまとめています。

## 1. `lib/redis_pool.rb` — 実害のあるバグ

| 場所 | 現行 | 問題 |
|---|---|---|
| `config/database.yml:20` | `fetch("RAILS_MAX_THREADS") { 5 }` | — |
| `config/puma.rb:30` | `fetch('RAILS_MAX_THREADS', 3)` | pool 5 > threads 3 で OK |
| **`lib/redis_pool.rb:29`** | **`size: fetch('RAILS_MAX_THREADS', 2)`, `timeout: 1`** | **2 < 3。Pumaの3スレッドが2接続を奪い合い、1秒で `ConnectionPool::TimeoutError`** |

```ruby
size: ENV.fetch('REDIS_POOL_SIZE') { ENV.fetch('RAILS_MAX_THREADS', 5) }.to_i,
timeout: ENV.fetch('REDIS_TIMEOUT', 5).to_f
```

`Redis.new` にも既定URLと `connect/read/write timeout` / `reconnect_attempts` を追加しました。`app/controllers/spotify/playlists_controller.rb` が進捗を継続的に Redis へ書き込むため、ここが詰まると管理画面が固まります。

> **挙動変更**: `REDIS_TIMEOUT` の既定が Integer `1` → Float `5` になります。プール枯渇時の待ち時間が5倍になりますが、そもそも枯渇しないようサイズを増やしたのが本質です。

## 2. `config/database.yml` — Webとワーカーの両方を満たす式に

`pool:` は `default: &default` アンカーに1箇所だけ定義され、全環境・全DBが `<<: *default` で継承しています。同じ設定を Puma（3スレッド）と Solid Queue ワーカー（`threads: 3` × `JOB_CONCURRENCY`）が共有するため、両方を満たす式にしました。

```yaml
pool: <%= [ENV.fetch("RAILS_MAX_THREADS", 5).to_i, ENV.fetch("JOB_CONCURRENCY", 1).to_i * 3].max + 2 %>
```

既定値は7です（`RAILS_MAX_THREADS=8` なら10）。

## 3. `config/puma.rb` — コメントのみ

`workers` / `preload_app!` は**追加していません**。`plugin :solid_queue if ENV['SOLID_QUEUE_IN_PUMA']` と cluster + preload を組み合わせると fork 後のDB/Redis接続の再確立を各所で考慮する必要が生じ、低トラフィックな内部管理アプリでは便益に対してリスクが高いためです。プールとの関係を説明するコメントのみ追加しました。

## 4. `app/models/parallel_runner.rb`（新規）

6箇所に散在していたワーカー数を集約しました。

```ruby
WORKERS = { ytmusic: 7, line_music: 4, spotify: 3 }.freeze
```

ワーカー数の決定順序は `forced_workers` > `ENV['PARALLEL_WORKERS']` > 呼び出し側の `workers:` 引数で、最後に `[決定値, Parallel.processor_count].min` で頭打ちにします。

**`ENV['PARALLEL_WORKERS']` がこれで初めて実際に機能します。** `.githooks/pre-push` は以前から設定していましたが、コード側で誰も読んでおらず無効な環境変数でした。

`Parallel` への直接参照は `parallel_runner.rb` の1箇所だけになりました（`grep` で確認済み）。

### `in_processes` を維持した理由

- これらの経路は外部API待ちが主体で、`YtMusic::Client` / `LineMusic::Client` のシングルトンが保持する**メモ化済み Faraday コネクションが fork によってプロセスごとに分離される**ことで結果的に安全が保たれている。`:threads` に切り替えると本当に共有されてしまい危険度が上がる
- `ActiveSupport::ForkTracker` が子プロセス側でコネクションプールを破棄するため、「親子でソケットを共有して壊れる」古典的な事故は既に塞がれている
- 念のため fork 直前（レコードを materialize した後）にのみ `clear_all_connections!(:all)` を実行。進行中のトランザクションを壊さないためタイミングを厳守しています（Rails 8.1.3 でこのシグネチャが有効であることを確認済み）

**残存リスクも明記しました**: これらは Solid Queue のワーカースレッドから fork されるため、fork の瞬間に他スレッドが握っていたミューテックス（Logger 等）が子で解放されない可能性があります。ForkTracker はプールを救いますが Logger のミューテックスは救いません。

## 5. テストの Parallel モンキーパッチを解消

4つのテストファイルが `Parallel.define_singleton_method(:each)` でプロセスグローバルに差し替えており、`ensure` で戻してはいるものの、テストが途中で落ちるとパッチが残る実在のフレーク源でした。

`test/test_helper.rb` で `ParallelRunner.forced_workers = 1` に固定することで、**`ensure` 漏れによるリークが原理的に起きなく**なりました。`parallelize(workers: :number_of_processors)` は無効化していません。

## テスト

`test/models/parallel_runner_test.rb` を新規追加（144 → 156 runs）。Symbol/Integer の解決、`PARALLEL_WORKERS` と `forced_workers` の優先順位、`<= 1` での直列フォールバック、`finish:` が並列・直列の両経路で `(item, index, result)` を受け取ることを検証します。

> 実装中、pre-push hook が設定する `PARALLEL_WORKERS=1` 下でこれらのテストが落ちることを検知しました。テスト側が環境変数を中和しておらず、ambient な環境に依存していたためです（実装側の優先順位は意図どおり）。テストを環境非依存に修正し、`PARALLEL_WORKERS` 未設定 / `=1` / `=4` のすべてで green になることを確認しています。

## 検証

```
DBプール:    7（RAILS_MAX_THREADS=8 で 10）
Redisプール: 5、PING → PONG
```

- `RAILS_ENV=test bin/rails test` → 156 runs, 1072 assertions, 0 failures
- `PARALLEL_WORKERS=1` / `PARALLEL_WORKERS=4` / `CI=true` / `PARALLEL_WORKERS=1 CI=true` の各組み合わせ → いずれも 156 runs, 0 failures
- シードを変えた5回連続実行（11/22/33/44/55）→ すべて 156 runs, 0 failures（フレークなし）
- `RAILS_ENV=test` / `RAILS_ENV=production` の `zeitwerk:check` → ともに All is good!
- `bundle exec rubocop --parallel` → 217 files inspected, no offenses detected