### PR TITLE
rubocop-minitestを導入しMinitest固有の指摘に対応

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ inherit_from:
 plugins:
   - rubocop-rails
   - rubocop-performance
+  - rubocop-minitest
 
 AllCops:
   TargetRubyVersion: 4.0
@@ -58,3 +59,16 @@ Style/OpenStructUse:
 Rails/SkipsModelValidations:
   Exclude:
     - 'db/migrate/*active_storage*'
+
+# percentage系の値は ((value.to_f / total) * 1000).floor / 10.0 で算出され、
+# 厳密に比較可能な double になるため assert_equal で問題ない。
+# 「切り上げが起きないこと」を検証する境界値テストでは完全一致であることに意味があり、
+# 許容誤差を導入するとテストの意図が弱まる。
+Minitest/AssertInDelta:
+  Enabled: false
+
+# 本リポジトリは Metrics/AbcSize, BlockLength, CyclomaticComplexity, MethodLength,
+# PerceivedComplexity, ClassLength をいずれも無効化している（.rubocop_base.yml 参照）。
+# Minitest/MultipleAssertions は実質テスト版の Metrics cop であり、この方針に揃える。
+Minitest/MultipleAssertions:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ end
 group :development do
   gem 'listen', '~> 3.8'
   gem 'rubocop', require: false
+  gem 'rubocop-minitest', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,10 @@ GEM
     rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-minitest (0.40.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-performance (1.26.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
@@ -417,6 +421,7 @@ DEPENDENCIES
   redis
   rspotify
   rubocop
+  rubocop-minitest
   rubocop-performance
   rubocop-rails
   solid_queue (~> 1.5)

--- a/test/controllers/admin/original_song_assignments_controller_test.rb
+++ b/test/controllers/admin/original_song_assignments_controller_test.rb
@@ -107,6 +107,7 @@ module Admin
       assert_response :success
       options = response.parsed_body.fetch('options')
       option_values = options.map { |option| option.fetch('value') }
+
       assert_equal ['ASSIGN-OPTION-001'], option_values
       assert_match(/Needle Mountain/, options.first.fetch('label'))
     end
@@ -123,6 +124,7 @@ module Admin
       resolutions = response.parsed_body.fetch('resolutions')
       resolution_queries = resolutions.map { |resolution| resolution.fetch('query') }
       resolution_option_values = resolutions.map { |resolution| resolution.fetch('options').pluck('value') }
+
       assert_equal ['Paste First', 'Paste Second', 'ASSIGN-PASTE-003'], resolution_queries
       assert_equal [[first_song.code], [second_song.code], [third_song.code]], resolution_option_values
     end
@@ -139,6 +141,7 @@ module Admin
       resolutions = response.parsed_body.fetch('resolutions')
       resolution_queries = resolutions.map { |resolution| resolution.fetch('query') }
       resolution_option_values = resolutions.map { |resolution| resolution.fetch('options').pluck('value') }
+
       assert_equal [comma_song.title, slash_song.title, ascii_comma_song.title], resolution_queries
       assert_equal [[comma_song.code], [slash_song.code], [ascii_comma_song.code]], resolution_option_values
     end
@@ -156,6 +159,7 @@ module Admin
       resolutions = response.parsed_body.fetch('resolutions')
       resolution_queries = resolutions.map { |resolution| resolution.fetch('query') }
       resolution_option_values = resolutions.map { |resolution| resolution.fetch('options').pluck('value') }
+
       assert_equal [comma_song.title, slash_song.title, ascii_comma_song.title, plain_song.title], resolution_queries
       assert_equal [[comma_song.code], [slash_song.code], [ascii_comma_song.code], [plain_song.code]], resolution_option_values
     end
@@ -170,6 +174,7 @@ module Admin
       assert_response :success
       options = response.parsed_body.fetch('resolutions').first.fetch('options')
       option_values = options.map { |option| option.fetch('value') }
+
       assert_equal [first_song.code, second_song.code], option_values
     end
 
@@ -182,6 +187,7 @@ module Admin
       assert_response :success
       options = response.parsed_body.fetch('resolutions').first.fetch('options')
       option_values = options.map { |option| option.fetch('value') }
+
       assert_equal [song.code], option_values
     end
 
@@ -194,6 +200,7 @@ module Admin
       assert_response :success
       options = response.parsed_body.fetch('resolutions').first.fetch('options')
       option_values = options.map { |option| option.fetch('value') }
+
       assert_equal [song.code], option_values
     end
 
@@ -206,6 +213,7 @@ module Admin
       assert_response :success
       options = response.parsed_body.fetch('resolutions').first.fetch('options')
       option_values = options.map { |option| option.fetch('value') }
+
       assert_equal [song.code], option_values
     end
 
@@ -227,6 +235,7 @@ module Admin
       resolutions = response.parsed_body.fetch('resolutions')
       resolution_queries = resolutions.map { |resolution| resolution.fetch('query') }
       resolution_option_values = resolutions.map { |resolution| resolution.fetch('options').pluck('value') }
+
       assert_equal ['妖魔夜行', 'U.N.オーエンは彼女なのか?'], resolution_queries
       assert_equal [[first_song.code], [second_song.code]], resolution_option_values
     end

--- a/test/controllers/admin/resources_controller_test.rb
+++ b/test/controllers/admin/resources_controller_test.rb
@@ -336,6 +336,7 @@ module Admin
       assert_select 'select[name=?] option', 'filters[original_songs_count]', text: '0曲'
       assert_select 'th', text: '配信取得'
       row_jan_codes = css_select('tbody tr').map { |row| row.css('td')[3].text.squish }
+
       assert_equal [newer_track.jan_code, older_track.jan_code], row_jan_codes
       assert_select 'a.admin-streaming-status-badge', text: 'Spotify未取得'
       assert_select 'a[href=?].admin-streaming-status-badge', admin_resources_path('tracks', filters: { missing_streaming_track: :apple_music }), text: 'Apple Music未取得'
@@ -373,12 +374,14 @@ module Admin
       assert_response :success
       assert_select 'a.admin-sort-link.is-active[aria-sort=?]', 'ascending', text: '名前'
       row_names = css_select('tbody tr').map { |row| row.css('td').first.text.squish }
+
       assert_equal [lower_spotify_album.name, upper_spotify_album.name], row_names
 
       get admin_resources_url('spotify_albums'), params: { q: 'Admin Sort', sort: 'name', direction: 'desc' }
 
       assert_response :success
       row_names = css_select('tbody tr').map { |row| row.css('td').first.text.squish }
+
       assert_equal [upper_spotify_album.name, lower_spotify_album.name], row_names
     end
 
@@ -624,6 +627,7 @@ module Admin
       assert_response :success
       options = JSON.parse(@response.body).fetch('options')
       option_values = options.map { |option| option.fetch('value') }
+
       assert_equal [album.id.to_s], option_values
       assert_match(/#{album.jan_code}.+Admin Edit Select Album/, options.first.fetch('label'))
 
@@ -636,6 +640,7 @@ module Admin
 
       assert_redirected_to admin_resource_path('spotify_tracks', spotify_track)
       spotify_track.reload
+
       assert_equal other_album.id, spotify_track.album_id
       assert_equal 'spotify-admin-edit-readonly-track', spotify_track.spotify_id
     end
@@ -716,6 +721,7 @@ module Admin
 
       assert_response :success
       row_spotify_ids = css_select('tbody tr').map { |row| row.css('td').first.text.squish }
+
       assert_equal(
         [newer_first_feature.spotify_id, newer_second_feature.spotify_id, older_feature.spotify_id],
         row_spotify_ids
@@ -1091,9 +1097,11 @@ module Admin
       end
 
       circle = Circle.find_by!(name: 'New Admin Circle')
+
       assert_redirected_to admin_resource_path('circles', circle)
 
       patch admin_resource_url('circles', circle), params: { record: { name: 'Updated Admin Circle' } }
+
       assert_redirected_to admin_resource_path('circles', circle)
       assert_equal 'Updated Admin Circle', circle.reload.name
 

--- a/test/jobs/admin/action_job_test.rb
+++ b/test/jobs/admin/action_job_test.rb
@@ -47,6 +47,7 @@ module Admin
       end
 
       actual_file = action.calls.first.fetch(:fields).fetch('tsv_file')
+
       assert_instance_of Admin::ActionUploadedFile, actual_file
       assert_equal uploaded_file.path, actual_file.path
       assert_equal uploaded_file.content_type, actual_file.content_type

--- a/test/lib/tasks/touhou_music_discover_export_test.rb
+++ b/test/lib/tasks/touhou_music_discover_export_test.rb
@@ -30,6 +30,7 @@ class TouhouMusicDiscoverExportTest < ActiveSupport::TestCase
     Rake::Task['touhou_music_discover:export:spotify'].invoke
 
     output = export_path.read
+
     assert_includes output, 'Export Active Spotify Album'
     assert_includes output, 'Export Active Spotify Track'
     assert_not_includes output, 'Export Inactive Spotify Album'
@@ -66,6 +67,7 @@ class TouhouMusicDiscoverExportTest < ActiveSupport::TestCase
     end
 
     output = export_path.read
+
     tracks.each { |track| assert_includes output, track.isrc }
     original_songs.each { |original_song| assert_includes output, original_song.title }
     assert_operator original_song_queries, :<=, 1

--- a/test/models/admin/dashboard_metrics_test.rb
+++ b/test/models/admin/dashboard_metrics_test.rb
@@ -51,6 +51,7 @@ module Admin
       assert_equal 'spotify_tracks', spotify_coverage.fetch(:missing_track_action_resource_key)
       assert_equal 'fetch_missing_spotify_tracks', spotify_coverage.fetch(:missing_track_action_key)
       missing_track_sample_ids = spotify_coverage.fetch(:missing_track_samples).map { |track| track.fetch(:id) }
+
       assert_equal [track_without_spotify.id], missing_track_sample_ids
       assert_includes metrics.fetch(:work_queue).map { |item| item.fetch(:key) }, 'spotify_missing_albums'
       assert_includes metrics.fetch(:data_quality).map { |item| item.fetch(:key) }, 'spotify_tracks_missing_audio_features'

--- a/test/models/spotify_client_album_test.rb
+++ b/test/models/spotify_client_album_test.rb
@@ -58,6 +58,7 @@ module SpotifyClient
       end
 
       spotify_album = SpotifyAlbum.unscoped.find_by!(album:)
+
       assert_equal "spotify-#{jan_code}", spotify_album.spotify_id
       assert_equal 'Spotify JAN Album', spotify_album.name
       assert_equal "upc:#{jan_code}", queries.last
@@ -106,6 +107,7 @@ module SpotifyClient
       end
 
       years = (2000..Time.zone.today.year).to_a
+
       assert_equal years, searched_years
       assert_equal(
         { current: 0, total: years.size, message: 'Spotify アルバムを取得しています', reset: true },

--- a/test/models/spotify_rate_limit_test.rb
+++ b/test/models/spotify_rate_limit_test.rb
@@ -16,6 +16,7 @@ class SpotifyRateLimitTest < ActiveSupport::TestCase
       assert_equal '54分27秒', status.retry_after_duration
 
       current = SpotifyRateLimit.current(now: observed_at + 10.seconds)
+
       assert_equal 3267, current.retry_after
       assert_equal 3257, current.remaining_seconds(now: observed_at + 10.seconds)
 

--- a/test/models/spotify_retry_test.rb
+++ b/test/models/spotify_retry_test.rb
@@ -62,10 +62,12 @@ class SpotifyRetryTest < ActiveSupport::TestCase
     end
 
     expected_bases = [5, 10, 20]
+
     assert_equal expected_bases.size, sleeps.size
 
     sleeps.each_with_index do |delay, index|
       base = expected_bases[index]
+
       assert_operator delay, :>=, base
       assert_operator delay, :<=, base * (1 + SpotifyRetry::JITTER)
     end
@@ -94,6 +96,7 @@ class SpotifyRetryTest < ActiveSupport::TestCase
       end
 
       status = SpotifyRateLimit.current
+
       assert_equal 5, status.retry_after
       assert_equal 'spec-source', status.source
     end

--- a/test/models/ytmusic_album_process_jan_to_album_browse_ids_test.rb
+++ b/test/models/ytmusic_album_process_jan_to_album_browse_ids_test.rb
@@ -38,6 +38,7 @@ class YtmusicAlbumProcessJanToAlbumBrowseIdsTest < ActiveSupport::TestCase
     end
 
     ytmusic_album = YtmusicAlbum.find_by!(album:, browse_id:)
+
     assert_equal 'YouTube Music Album', ytmusic_album.name
     assert_equal "https://music.youtube.com/browse/#{browse_id}", ytmusic_album.url
     assert_equal 'https://music.youtube.com/playlist?list=test', ytmusic_album.playlist_url


### PR DESCRIPTION
## 概要

テストが45ファイル以上あり、RuboCop 本体が毎回以下の Tip を出していました。

```
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-minitest
```

`rubocop-rails` / `rubocop-performance` では検出できない Minitest 固有の問題を拾えるようにします。このナグも（`SuggestExtensions: false` で握りつぶすのではなく）導入によって自然に消えます。

## 変更内容

- `Gemfile` の `group :development` に `gem 'rubocop-minitest', require: false` を追加（アルファベット順を維持）
- `.rubocop.yml` の `plugins:` に `rubocop-minitest` を追加

`Gemfile.lock` の差分は **`rubocop-minitest (0.40.0)` の追加のみ**で、既存 gem のバージョンは1つも動いていません（依存の `lint_roller` / `rubocop` / `rubocop-ast` はいずれも既存）。

## 検出されたオフェンスと対応

`.rubocop.yml` は `NewCops: enable` のため、全 Minitest cop が一斉に有効化されます。導入直後の内訳:

| cop | 件数 | 対応 |
|---|---|---|
| `Minitest/MultipleAssertions` | 58 | cop を無効化（下記） |
| `Minitest/EmptyLineBeforeAssertionMethods` | 28 | safe autocorrect で修正 |
| `Minitest/AssertInDelta` | 4 | cop を無効化し変換を差し戻し（下記） |

### 修正した28件

`Minitest/EmptyLineBeforeAssertionMethods` は**アサーション直前への空行挿入のみ**で、意味的に完全に等価です。9ファイルに適用しました。

安全な `--autocorrect` のみを使用し、**挙動を変えうる `--autocorrect-all`（unsafe）は使っていません**。

### 無効化した cop 1: `Minitest/AssertInDelta`

autocorrect は `test/models/admin/dashboard_metrics_test.rb` の4件を `assert_equal <float>, x` → `assert_in_delta(<float>, x)` に書き換えましたが、**これは改悪なので差し戻しました**。

`Admin::DashboardMetrics#percentage` の実装は以下で、`998 / 10.0` のような**厳密に比較可能な double** を返します。

```ruby
def percentage(value, total)
  return 0 if total.to_i.zero?
  return 100.0 if value.to_i >= total.to_i

  ((value.to_f / total) * 1000).floor / 10.0
end
```

さらに対象の1つは `'does not round incomplete coverage up to 100 percent'` というテストで、**3685/3691 が 99.8 になり 100.0 に切り上がらないことを検証する境界値テスト**です。完全一致であることにこそ意味があり、`assert_in_delta` の許容誤差（既定0.001）を導入するとテストの意図が弱まります。

> なお `test/lib/apple_music/config_test.rb:37` の `assert_in_delta ..., 5` は JWT の `exp` を許容誤差5秒で比較する正当な既存の用法で、そのまま維持しています。

### 無効化した cop 2: `Minitest/MultipleAssertions`

既定の `Max: 3` は厳しく、58件が該当しました（最大は `dashboard_controller_test.rb` の1テスト33アサーション）。

**本リポジトリは `Metrics/AbcSize` / `BlockLength` / `CyclomaticComplexity` / `MethodLength` / `PerceivedComplexity` / `ClassLength` をいずれも無効化する方針**です（`.rubocop_base.yml` / `.rubocop.yml`）。`Minitest/MultipleAssertions` は実質テスト版の Metrics cop なので、既存方針に揃えて無効化しました。

どちらも `.rubocop.yml` に日本語で理由をコメントとして残してあります。

## 検証

- `bundle exec rubocop --parallel` → **217 files inspected, no offenses detected**（Tip のナグも消滅）
- `bundle exec rubocop --parallel --only Minitest` → 217 files inspected, no offenses detected
- `CI=true RAILS_ENV=test bin/rails test` → 156 runs, **1072 assertions**, 0 failures, 0 errors, 0 skips
- `PARALLEL_WORKERS=1 RAILS_ENV=test bin/rails test` → 156 runs, **1072 assertions**, 0 failures, 0 errors, 0 skips
- `RAILS_ENV=test bin/rails zeitwerk:check` → All is good!

**アサーション数が 1072 のまま変わっていない**ことを確認済みです（autocorrect がアサーションの形を変えていれば数が動くため、意味が保たれている裏付けになります）。