### PR TITLE
プラットフォームテーブルの重複レコードを除去し再発を防止

### DIFF
--- a/app/models/apple_music_album.rb
+++ b/app/models/apple_music_album.rb
@@ -32,19 +32,20 @@ class AppleMusicAlbum < ApplicationRecord
 
     return nil if am_album.record_label != ::Album::TOUHOU_MUSIC_LABEL
 
-    apple_music_album = ::AppleMusicAlbum.find_or_create_by!(
-      apple_music_id: am_album.id,
-      name: am_album.name,
-      label: am_album.record_label,
-      url: am_album.url,
-      release_date: am_album.release_date,
-      total_tracks: am_album.track_count
-    )
+    apple_music_album = ::AppleMusicAlbum.find_or_create_by!(apple_music_id: am_album.id) do |record|
+      record.name = am_album.name
+      record.label = am_album.record_label
+    end
 
     jan_code = am_album.upc
     album = ::Album.find_or_create_by!(jan_code:)
 
     apple_music_album.update(
+      name: am_album.name,
+      label: am_album.record_label,
+      url: am_album.url,
+      release_date: am_album.release_date,
+      total_tracks: am_album.track_count,
       album_id: album.id,
       payload: am_album.as_json
     )

--- a/app/models/apple_music_artist.rb
+++ b/app/models/apple_music_artist.rb
@@ -2,12 +2,14 @@
 
 class AppleMusicArtist < ApplicationRecord
   def self.save_artist(am_artist)
-    apple_music_artist = AppleMusicArtist.find_or_create_by!(
-      apple_music_id: am_artist.id,
-      name: am_artist.name,
-      url: am_artist.url
-    )
+    apple_music_artist = AppleMusicArtist.find_or_create_by!(apple_music_id: am_artist.id) do |record|
+      record.name = am_artist.name
+    end
 
-    apple_music_artist.update!(payload: am_artist.as_json)
+    apple_music_artist.update!(
+      name: am_artist.name,
+      url: am_artist.url,
+      payload: am_artist.as_json
+    )
   end
 end

--- a/app/models/apple_music_track.rb
+++ b/app/models/apple_music_track.rb
@@ -25,9 +25,16 @@ class AppleMusicTrack < ApplicationRecord
     track = ::Track.find_or_create_by!(jan_code: apple_music_album.album.jan_code, isrc: am_track.isrc)
 
     apple_music_track = ::AppleMusicTrack.find_or_create_by!(
-      track_id: track.id,
       apple_music_album_id: apple_music_album.id,
-      apple_music_id: am_track.id,
+      apple_music_id: am_track.id
+    ) do |record|
+      record.track_id = track.id
+      record.label = apple_music_album.label
+      record.name = am_track.name
+    end
+
+    apple_music_track.update!(
+      track_id: track.id,
       name: am_track.name,
       label: apple_music_album.label,
       artist_name: am_track.artist_name,
@@ -36,9 +43,7 @@ class AppleMusicTrack < ApplicationRecord
       release_date: am_track.release_date,
       disc_number: am_track.disc_number,
       track_number: am_track.track_number,
-      duration_ms: am_track.duration_in_millis
-    )
-    apple_music_track.update!(
+      duration_ms: am_track.duration_in_millis,
       album_id: apple_music_album.album_id,
       payload: am_track.as_json
     )

--- a/app/models/line_music_track.rb
+++ b/app/models/line_music_track.rb
@@ -138,16 +138,23 @@ class LineMusicTrack < ApplicationRecord
     Rails.logger.info "LINE MUSIC トラック情報保存: #{lm_track.track_title} (ID: #{lm_track.track_id})"
 
     line_music_track = ::LineMusicTrack.find_or_create_by!(
+      line_music_album_id: lm_album.id,
+      line_music_id: lm_track.track_id
+    ) do |record|
+      record.album_id = album_id
+      record.track_id = track_id
+      record.name = lm_track.track_title
+    end
+
+    line_music_track.update(
       album_id:,
       track_id:,
-      line_music_album_id: lm_album.id,
-      line_music_id: lm_track.track_id,
       name: lm_track.track_title,
       url:,
       disc_number: lm_track.disc_number,
-      track_number: lm_track.track_number
+      track_number: lm_track.track_number,
+      payload: lm_track.as_json
     )
-    line_music_track.update(payload: lm_track.as_json)
     Rails.logger.info "LINE MUSIC トラック情報を保存しました: #{lm_track.track_title}"
   end
 

--- a/app/models/spotify_artist.rb
+++ b/app/models/spotify_artist.rb
@@ -8,13 +8,13 @@ class SpotifyArtist < ApplicationRecord
   def self.save_artist(s_artist)
     return nil if s_artist.blank?
 
-    spotify_artist = SpotifyArtist.find_or_create_by!(
-      spotify_id: s_artist.id,
-      name: s_artist.name,
-      url: s_artist.external_urls['spotify']
-    )
+    spotify_artist = SpotifyArtist.find_or_create_by!(spotify_id: s_artist.id) do |record|
+      record.name = s_artist.name
+    end
 
     spotify_artist.update!(
+      name: s_artist.name,
+      url: s_artist.external_urls['spotify'],
       follower_count: s_artist.followers['total'],
       payload: s_artist.as_json
     )

--- a/app/models/spotify_track.rb
+++ b/app/models/spotify_track.rb
@@ -26,19 +26,27 @@ class SpotifyTrack < ApplicationRecord
     spotify_album.album.tracks << track unless spotify_album.album.tracks.include?(track)
 
     spotify_track = ::SpotifyTrack.find_or_create_by!(
+      spotify_album_id: spotify_album.id,
+      spotify_id: s_track.id
+    ) do |record|
+      record.album_id = spotify_album.album.id
+      record.track_id = track.id
+      record.label = spotify_album.label
+      record.name = s_track.name
+    end
+
+    spotify_track.update!(
       album_id: spotify_album.album.id,
       track_id: track.id,
-      spotify_album_id: spotify_album.id,
-      spotify_id: s_track.id,
       name: s_track.name,
       label: spotify_album.label,
       url: s_track.external_urls['spotify'],
       release_date: spotify_album.release_date,
       disc_number: s_track.disc_number,
       track_number: s_track.track_number,
-      duration_ms: s_track.duration_ms
+      duration_ms: s_track.duration_ms,
+      payload: s_track.as_json
     )
-    spotify_track.update!(payload: s_track.as_json)
     spotify_track
   end
 

--- a/app/models/spotify_track_audio_feature.rb
+++ b/app/models/spotify_track_audio_feature.rb
@@ -7,9 +7,26 @@ class SpotifyTrackAudioFeature < ApplicationRecord
   def self.save_audio_features(spotify_track, track_af)
     return nil if spotify_track.blank? || track_af.blank?
 
-    st_audio_features = SpotifyTrackAudioFeature.find_or_create_by!(
+    st_audio_features = SpotifyTrackAudioFeature.find_or_create_by!(spotify_track_id: spotify_track.id) do |record|
+      record.track_id = spotify_track.track_id
+      record.spotify_id = spotify_track.spotify_id
+      record.acousticness = track_af.acousticness
+      record.danceability = track_af.danceability
+      record.duration_ms = track_af.duration_ms
+      record.energy = track_af.energy
+      record.instrumentalness = track_af.instrumentalness
+      record.key = track_af.key
+      record.liveness = track_af.liveness
+      record.loudness = track_af.loudness
+      record.mode = track_af.mode
+      record.speechiness = track_af.speechiness
+      record.tempo = track_af.tempo
+      record.time_signature = track_af.time_signature
+      record.valence = track_af.valence
+    end
+
+    st_audio_features.update(
       track_id: spotify_track.track_id,
-      spotify_track_id: spotify_track.id,
       spotify_id: spotify_track.spotify_id,
       acousticness: track_af.acousticness,
       danceability: track_af.danceability,
@@ -23,9 +40,7 @@ class SpotifyTrackAudioFeature < ApplicationRecord
       speechiness: track_af.speechiness,
       tempo: track_af.tempo,
       time_signature: track_af.time_signature,
-      valence: track_af.valence
-    )
-    st_audio_features.update(
+      valence: track_af.valence,
       analysis_url: track_af.analysis_url.to_s,
       payload: track_af.as_json
     )

--- a/app/models/ytmusic_album.rb
+++ b/app/models/ytmusic_album.rb
@@ -87,9 +87,11 @@ class YtmusicAlbum < ApplicationRecord
   }.freeze
 
   def self.save_album(album_id, browse_id, album)
-    find_or_create_by!(
-      album_id:,
-      browse_id:,
+    ytmusic_album = find_or_create_by!(album_id:, browse_id:) do |record|
+      record.name = album.title
+    end
+
+    ytmusic_album.update!(
       name: album.title,
       url: "https://music.youtube.com/browse/#{browse_id}",
       playlist_url: album.playlist_url,
@@ -97,6 +99,7 @@ class YtmusicAlbum < ApplicationRecord
       release_year: album.year,
       payload: album.as_json
     )
+    ytmusic_album
   end
 
   def self.search_and_save(query, album)

--- a/app/models/ytmusic_track.rb
+++ b/app/models/ytmusic_track.rb
@@ -103,16 +103,24 @@ class YtmusicTrack < ApplicationRecord
     return unless url.include?(video_id.to_s) && url.include?(playlist_id.to_s)
 
     ytmusic_track = ::YtmusicTrack.find_or_create_by!(
-      album_id:,
-      track_id:,
       ytmusic_album_id: ytm_album.id,
-      video_id: video_id,
-      playlist_id: playlist_id,
+      track_id:
+    ) do |record|
+      record.album_id = album_id
+      record.video_id = video_id
+      record.playlist_id = playlist_id
+      record.name = title
+    end
+
+    ytmusic_track.update(
+      album_id:,
+      video_id:,
+      playlist_id:,
       name: title,
-      url: url,
-      track_number: track_number
+      url:,
+      track_number:,
+      payload: payload_track
     )
-    ytmusic_track.update(payload: payload_track)
   end
 
   def update_track(ytm_track)

--- a/db/migrate/20260726120000_add_unique_indexes_to_platform_tables.rb
+++ b/db/migrate/20260726120000_add_unique_indexes_to_platform_tables.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexesToPlatformTables < ActiveRecord::Migration[8.1]
+  def up
+    # apple_music_albums: 既存の非unique indexをunique indexに置き換え
+    remove_index :apple_music_albums, :apple_music_id, name: 'index_apple_music_albums_on_apple_music_id'
+    add_index :apple_music_albums, :apple_music_id, unique: true,
+                                                    name: 'index_apple_music_albums_on_apple_music_id'
+
+    # apple_music_tracks: 複合unique index（新規）
+    add_index :apple_music_tracks, %i[apple_music_album_id apple_music_id], unique: true,
+                                                                            name: 'index_apple_music_tracks_on_am_album_id_and_am_id'
+
+    # spotify_tracks: 複合unique index（新規）
+    add_index :spotify_tracks, %i[spotify_album_id spotify_id], unique: true,
+                                                                name: 'index_spotify_tracks_on_spotify_album_id_and_spotify_id'
+
+    # spotify_track_audio_features: 既存の非unique indexをunique indexに置き換え
+    remove_index :spotify_track_audio_features, :spotify_track_id,
+                 name: 'index_spotify_track_audio_features_on_spotify_track_id'
+    add_index :spotify_track_audio_features, :spotify_track_id, unique: true,
+                                                                name: 'index_spotify_track_audio_features_on_spotify_track_id'
+
+    # line_music_albums: 複合unique index（新規、単独外部IDでのuniqueは不可のため複合）
+    add_index :line_music_albums, %i[album_id line_music_id], unique: true,
+                                                              name: 'index_line_music_albums_on_album_id_and_line_music_id'
+
+    # line_music_tracks: 複合unique index（新規）
+    add_index :line_music_tracks, %i[line_music_album_id line_music_id], unique: true,
+                                                                         name: 'index_line_music_tracks_on_lm_album_id_and_lm_id'
+
+    # ytmusic_albums: 複合unique index（新規、単独外部IDでのuniqueは不可のため複合）
+    add_index :ytmusic_albums, %i[album_id browse_id], unique: true,
+                                                       name: 'index_ytmusic_albums_on_album_id_and_browse_id'
+
+    # ytmusic_tracks: 複合unique index（新規、video_idはディスク跨ぎ誤マッチのため使えない）
+    add_index :ytmusic_tracks, %i[ytmusic_album_id track_id], unique: true,
+                                                              name: 'index_ytmusic_tracks_on_ytmusic_album_id_and_track_id'
+
+    # apple_music_artists: 新規unique index（既存index無し）
+    add_index :apple_music_artists, :apple_music_id, unique: true,
+                                                     name: 'index_apple_music_artists_on_apple_music_id'
+
+    # spotify_artists: 新規unique index（既存index無し）
+    add_index :spotify_artists, :spotify_id, unique: true,
+                                             name: 'index_spotify_artists_on_spotify_id'
+  end
+
+  def down
+    remove_index :spotify_artists, name: 'index_spotify_artists_on_spotify_id'
+    remove_index :apple_music_artists, name: 'index_apple_music_artists_on_apple_music_id'
+    remove_index :ytmusic_tracks, name: 'index_ytmusic_tracks_on_ytmusic_album_id_and_track_id'
+    remove_index :ytmusic_albums, name: 'index_ytmusic_albums_on_album_id_and_browse_id'
+    remove_index :line_music_tracks, name: 'index_line_music_tracks_on_lm_album_id_and_lm_id'
+    remove_index :line_music_albums, name: 'index_line_music_albums_on_album_id_and_line_music_id'
+
+    remove_index :spotify_track_audio_features,
+                 name: 'index_spotify_track_audio_features_on_spotify_track_id'
+    add_index :spotify_track_audio_features, :spotify_track_id,
+              name: 'index_spotify_track_audio_features_on_spotify_track_id'
+
+    remove_index :spotify_tracks, name: 'index_spotify_tracks_on_spotify_album_id_and_spotify_id'
+    remove_index :apple_music_tracks, name: 'index_apple_music_tracks_on_am_album_id_and_am_id'
+
+    remove_index :apple_music_albums, name: 'index_apple_music_albums_on_apple_music_id'
+    add_index :apple_music_albums, :apple_music_id,
+              name: 'index_apple_music_albums_on_apple_music_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -35,7 +35,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.datetime "updated_at", null: false
     t.string "url"
     t.index ["album_id"], name: "index_apple_music_albums_on_album_id"
-    t.index ["apple_music_id"], name: "index_apple_music_albums_on_apple_music_id"
+    t.index ["apple_music_id"], name: "index_apple_music_albums_on_apple_music_id", unique: true
   end
 
   create_table "apple_music_artists", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
@@ -45,6 +45,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.jsonb "payload"
     t.datetime "updated_at", null: false
     t.string "url"
+    t.index ["apple_music_id"], name: "index_apple_music_artists_on_apple_music_id", unique: true
   end
 
   create_table "apple_music_tracks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
@@ -65,6 +66,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.datetime "updated_at", null: false
     t.string "url", default: "", null: false
     t.index ["album_id"], name: "index_apple_music_tracks_on_album_id"
+    t.index ["apple_music_album_id", "apple_music_id"], name: "index_apple_music_tracks_on_am_album_id_and_am_id", unique: true
     t.index ["apple_music_album_id"], name: "index_apple_music_tracks_on_apple_music_album_id"
     t.index ["apple_music_id"], name: "index_apple_music_tracks_on_apple_music_id"
     t.index ["track_id"], name: "index_apple_music_tracks_on_track_id"
@@ -96,6 +98,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.integer "total_tracks"
     t.datetime "updated_at", null: false
     t.string "url"
+    t.index ["album_id", "line_music_id"], name: "index_line_music_albums_on_album_id_and_line_music_id", unique: true
     t.index ["album_id"], name: "index_line_music_albums_on_album_id"
     t.index ["line_music_id"], name: "index_line_music_albums_on_line_music_id"
   end
@@ -113,6 +116,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.datetime "updated_at", null: false
     t.string "url", default: "", null: false
     t.index ["album_id"], name: "index_line_music_tracks_on_album_id"
+    t.index ["line_music_album_id", "line_music_id"], name: "index_line_music_tracks_on_lm_album_id_and_lm_id", unique: true
     t.index ["line_music_album_id"], name: "index_line_music_tracks_on_line_music_album_id"
     t.index ["line_music_id"], name: "index_line_music_tracks_on_line_music_id"
     t.index ["track_id"], name: "index_line_music_tracks_on_track_id"
@@ -173,6 +177,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.string "spotify_id", null: false
     t.datetime "updated_at", null: false
     t.string "url"
+    t.index ["spotify_id"], name: "index_spotify_artists_on_spotify_id", unique: true
   end
 
   create_table "spotify_playlists", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -213,7 +218,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.uuid "track_id", null: false
     t.datetime "updated_at", null: false
     t.float "valence", null: false
-    t.index ["spotify_track_id"], name: "index_spotify_track_audio_features_on_spotify_track_id"
+    t.index ["spotify_track_id"], name: "index_spotify_track_audio_features_on_spotify_track_id", unique: true
     t.index ["track_id"], name: "index_spotify_track_audio_features_on_track_id"
   end
 
@@ -233,6 +238,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.datetime "updated_at", null: false
     t.string "url"
     t.index ["album_id"], name: "index_spotify_tracks_on_album_id"
+    t.index ["spotify_album_id", "spotify_id"], name: "index_spotify_tracks_on_spotify_album_id_and_spotify_id", unique: true
     t.index ["spotify_album_id"], name: "index_spotify_tracks_on_spotify_album_id"
     t.index ["spotify_id"], name: "index_spotify_tracks_on_spotify_id"
     t.index ["track_id"], name: "index_spotify_tracks_on_track_id"
@@ -281,6 +287,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.integer "total_tracks"
     t.datetime "updated_at", null: false
     t.string "url"
+    t.index ["album_id", "browse_id"], name: "index_ytmusic_albums_on_album_id_and_browse_id", unique: true
     t.index ["album_id"], name: "index_ytmusic_albums_on_album_id"
     t.index ["browse_id"], name: "index_ytmusic_albums_on_browse_id"
   end
@@ -300,6 +307,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_010205) do
     t.index ["album_id"], name: "index_ytmusic_tracks_on_album_id"
     t.index ["track_id"], name: "index_ytmusic_tracks_on_track_id"
     t.index ["video_id"], name: "index_ytmusic_tracks_on_video_id"
+    t.index ["ytmusic_album_id", "track_id"], name: "index_ytmusic_tracks_on_ytmusic_album_id_and_track_id", unique: true
     t.index ["ytmusic_album_id"], name: "index_ytmusic_tracks_on_ytmusic_album_id"
   end
 

--- a/lib/dedupe/platform_records.rb
+++ b/lib/dedupe/platform_records.rb
@@ -1,0 +1,663 @@
+# frozen_string_literal: true
+
+module Dedupe
+  # 配信プラットフォーム別テーブルに蓄積した重複行を安全に取り除く。
+  #
+  # 重複は `find_or_create_by!` に一意キー以外の属性まで渡していたことで発生している。
+  # ここでは「同じ一意キーを持つ行」を1グループとして扱い、1行だけ残して他を削除する。
+  #
+  # 残す1行の基準:
+  #   - 原則: created_at 昇順 → id 昇順で先頭（＝最古）を残す
+  #   - 例外1: SpotifyTrackAudioFeature は created_at 降順 → id 昇順で先頭（＝最新）を残す。
+  #     Spotifyの再解析によって tempo 等の値が更新されているため、新しい行のほうが正しい。
+  #   - 例外2: LineMusicTrack も最新を残す。2022年に作成された行は ISRC が track_number に対して
+  #     1つずれており、Spotify/Apple Music の (disc_number, track_number) → ISRC 対応と一致しない。
+  #   - 例外3: YtmusicTrack は created_at では正しい行を選べない（同じ track_id に対して video_id が異なる）。
+  #     親 ytmusic_albums.payload に載っている video_id を持つ行を優先し、一意に決まらない場合のみ最古に落とす。
+  #
+  # 子テーブルを持つ親（AppleMusicAlbum / YtmusicAlbum / SpotifyTrack）の loser を削除すると、
+  # keeper へ付け替えられなかった子は `dependent: :destroy` で連鎖削除される。
+  # この連鎖削除も「削除件数」として安全装置・サマリ・削除ログに算入する。
+  #
+  # 親テーブル（AppleMusicAlbum / YtmusicAlbum）は loser を削除する前に、グループ内で最も新しい行の
+  # 属性を keeper へマージする。最古を残す方針のままでは、後から取得し直した正しい name / url /
+  # release_date を捨ててしまうため。
+  #
+  # 実行は既定でdry-run。`apply: true` を指定したときだけ、安全装置を通過した場合に限り削除する。
+  class PlatformRecords
+    DEFAULT_MAX_DELETIONS = 1500
+    DEFAULT_MAX_RATIO = 0.05
+
+    # 一度のSQLで扱うキー・IDの最大数（WHERE句が肥大化しないように分割する）
+    BATCH_SIZE = 200
+    # dry-run時に表示する重複グループのサンプル件数
+    SAMPLE_SIZE = 5
+
+    # 重複親の削除に巻き込まれる子テーブルの定義。
+    # unique_keys は「FK を除いた」子自身の一意キー。
+    # 空配列の場合は「keeper 側に子が1件でもあれば付け替えない」という意味になる
+    # （SpotifyTrackAudioFeature のように spotify_track_id 自体が一意キーであるケース）。
+    Child = Struct.new(:model_name, :foreign_key, :unique_keys, keyword_init: true) do
+      def model
+        model_name.constantize
+      end
+    end
+
+    # 重複除去の対象テーブル定義。
+    #   keep                    : 残す1行の選び方（:oldest / :newest）
+    #   keeper_selector         : created_at では決められないテーブル用。指定するとそのメソッドが keeper を選ぶ
+    #   extra_columns           : keeper_selector が参照するために追加で取得する列
+    #   merge_latest_attributes : loser 削除前にグループ内最新行の属性を keeper へマージするか
+    Target = Struct.new(
+      :model_name, :unique_keys, :keep, :child, :keeper_selector, :extra_columns, :merge_latest_attributes,
+      keyword_init: true
+    ) do
+      def initialize(extra_columns: [], merge_latest_attributes: false, **rest)
+        super
+      end
+
+      def model
+        model_name.constantize
+      end
+    end
+
+    # 処理順序は親テーブルが先。親を先に片付けることで、子テーブルの重複除去時には
+    # 付け替え済みの状態を見られるようにする。
+    TARGETS = [
+      Target.new(
+        model_name: 'AppleMusicAlbum',
+        unique_keys: %i[apple_music_id],
+        keep: :oldest,
+        child: Child.new(model_name: 'AppleMusicTrack', foreign_key: :apple_music_album_id, unique_keys: %i[apple_music_id]),
+        merge_latest_attributes: true
+      ),
+      Target.new(
+        model_name: 'YtmusicAlbum',
+        unique_keys: %i[album_id browse_id],
+        keep: :oldest,
+        child: Child.new(model_name: 'YtmusicTrack', foreign_key: :ytmusic_album_id, unique_keys: %i[track_id]),
+        merge_latest_attributes: true
+      ),
+      Target.new(model_name: 'AppleMusicTrack', unique_keys: %i[apple_music_album_id apple_music_id], keep: :oldest),
+      Target.new(
+        model_name: 'SpotifyTrack',
+        unique_keys: %i[spotify_album_id spotify_id],
+        keep: :oldest,
+        child: Child.new(model_name: 'SpotifyTrackAudioFeature', foreign_key: :spotify_track_id, unique_keys: [])
+      ),
+      # 2022年作成の行は ISRC が1つずれており、Spotify/Apple Music の (disc_number, track_number) → ISRC 対応と
+      # 一致しない。実測では新しい行が 7/7 一致・古い行が 0/7 一致だったため最新を残す。
+      Target.new(model_name: 'LineMusicTrack', unique_keys: %i[line_music_album_id line_music_id], keep: :newest),
+      # 同じ track_id に対して video_id が異なる重複のため created_at では正しい行を選べない。
+      # 親 ytmusic_albums.payload に載っている video_id を持つ行を優先する。
+      Target.new(
+        model_name: 'YtmusicTrack',
+        unique_keys: %i[ytmusic_album_id track_id],
+        keep: :oldest,
+        keeper_selector: :select_ytmusic_track_keeper_first,
+        extra_columns: %i[video_id]
+      ),
+      Target.new(model_name: 'SpotifyTrackAudioFeature', unique_keys: %i[spotify_track_id], keep: :newest)
+    ].freeze
+
+    # loser の destroy! に巻き込まれて消える子1行ぶんの記録。key は「列名 => 値」のハッシュ。
+    CascadedChild = Struct.new(:id, :created_at, :key, keyword_init: true)
+
+    # 削除対象1行ぶんの計画。
+    # reassigned_child_ids は keeper へ付け替える子のid、cascaded_children は dependent: :destroy で道連れになる子。
+    Loser = Struct.new(:id, :created_at, :reassigned_child_ids, :cascaded_children, keyword_init: true)
+
+    # 同じ一意キーを持つ行の集まり。key は「列名 => 値」のハッシュ。
+    #   keeper_reason   : keeper_selector で選んだ場合の選定理由（それ以外は nil）
+    #   merge_source_id : 属性マージ元となるグループ内最新行のid（keeper自身が最新なら nil）
+    #   attribute_merge : `{ source_id:, changes: { 列名 => { from:, to: } } }`。差分があるときだけ入る
+    Group = Struct.new(:key, :keeper_id, :keeper_reason, :losers, :merge_source_id, :attribute_merge, keyword_init: true)
+
+    # テーブル1つぶんの計画。child_total_count は子テーブルの総行数（子を持たないテーブルは nil）。
+    Plan = Struct.new(:target, :total_count, :child_total_count, :groups, keyword_init: true) do
+      def deletion_count
+        groups.sum { |group| group.losers.size }
+      end
+
+      def reassignment_count
+        groups.sum { |group| group.losers.sum { |loser| loser.reassigned_child_ids.size } }
+      end
+
+      # 実際に差分があり、keeper へ属性マージが起きるグループ数。
+      def merge_count
+        groups.count(&:attribute_merge)
+      end
+
+      # dependent: :destroy によって子テーブルから消える行数。
+      def cascaded_count
+        groups.sum { |group| group.losers.sum { |loser| loser.cascaded_children.size } }
+      end
+
+      def deletion_ratio
+        return 0.0 if total_count.zero?
+
+        deletion_count.to_f / total_count
+      end
+
+      # 子テーブル全体に対する連鎖削除の比率。自テーブルの削除比率とは独立に判定する。
+      def cascaded_ratio
+        return 0.0 if child_total_count.nil? || child_total_count.zero?
+
+        cascaded_count.to_f / child_total_count
+      end
+    end
+
+    SUMMARY_FORMAT = '%<model>-26s %<total>10s %<groups>12s %<deletions>10s %<cascaded>12s ' \
+                     '%<reassignments>14s %<merges>12s %<keep>10s'
+
+    # 属性マージのコピー対象から常に外す列。updated_at は update! が必ず現在時刻で上書きするため、
+    # 差分として記録しても意味がない。
+    NON_MERGEABLE_COLUMNS = %w[id created_at updated_at].freeze
+
+    def initialize(apply: false, max_deletions: DEFAULT_MAX_DELETIONS, max_ratio: DEFAULT_MAX_RATIO, out: $stdout)
+      @apply = apply
+      @max_deletions = max_deletions
+      @max_ratio = max_ratio
+      @out = out
+      @ytmusic_album_video_ids = {}
+    end
+
+    # プラン作成 → サマリ出力 → 安全装置チェック → (APPLY時のみ)実行 → ログ書き込み
+    def run
+      print_header
+      plans = TARGETS.map { |target| build_plan(target) }
+      print_summary(plans)
+      print_samples(plans) unless apply?
+
+      violations = safety_violations(plans)
+      print_violations(violations)
+
+      log_rows = []
+      log_path = nil
+
+      if violations.any?
+        print_abort_notice
+      elsif apply?
+        log_rows = execute(plans)
+        log_path = write_log(log_rows)
+        print_deletion_counts(log_rows)
+        out.puts "削除ログ: #{log_path}" if log_path
+      else
+        out.puts 'dry-run のため削除していません。実削除するには APPLY=1 を付けて再実行してください。'
+      end
+
+      build_result(plans:, violations:, log_rows:, log_path:)
+    end
+
+    private
+
+    attr_reader :max_deletions, :max_ratio, :out
+
+    def apply? = @apply
+
+    # ------------------------------------------------------------------
+    # プラン作成フェーズ（読み取り専用。DBは一切変更しない）
+    # ------------------------------------------------------------------
+
+    def build_plan(target)
+      # default_scope の includes(:album).order(...) が集計・削除の邪魔になるため、常に unscoped を使う。
+      total_count = target.model.unscoped.count
+      child_total_count = target.child && target.child.model.unscoped.count
+
+      groups = duplicate_records(target).group_by { |record| key_of(record, target.unique_keys) }
+                                        .map { |key, records| build_group(key, records, target) }
+      assign_child_plans(target, groups) if target.child
+      assign_attribute_merges(target, groups) if target.merge_latest_attributes
+
+      Plan.new(target:, total_count:, child_total_count:, groups:)
+    end
+
+    def build_group(key, records, target)
+      ordered, reason = select_keeper(target, records)
+      keeper, *losers = ordered
+
+      Group.new(
+        key:,
+        keeper_id: keeper.id,
+        keeper_reason: reason,
+        losers: losers.map { |record| build_loser(record) },
+        merge_source_id: merge_source_id_for(target, records, keeper.id)
+      )
+    end
+
+    # keeper を先頭に並べた配列と、その選定理由（created_at 順に選んだ場合は nil）を返す。
+    def select_keeper(target, records)
+      return send(target.keeper_selector, records) if target.keeper_selector
+
+      [sort_by_keep(records, target.keep), nil]
+    end
+
+    # 親アルバムの payload に載っている video_id を持つ行を優先する。
+    # 一意に決まらない場合（0件 / 複数件）は created_at 最古へフォールバックする。
+    def select_ytmusic_track_keeper_first(records)
+      # ytmusic_album_id は一意キーの一部なので、グループ内の全行で同じ値になる。
+      known_video_ids = ytmusic_album_video_ids(records.first[:ytmusic_album_id])
+      matches = records.select { |record| known_video_ids.include?(record[:video_id]) }
+
+      if matches.one?
+        keeper = matches.first
+        rest = records.reject { |record| record.id == keeper.id }
+        return [[keeper, *sort_by_keep(rest, :oldest)], 'album.payloadのvideo_idと一致']
+      end
+
+      [sort_by_keep(records, :oldest), ytmusic_track_fallback_reason(matches)]
+    end
+
+    def ytmusic_track_fallback_reason(matches)
+      return 'album.payloadに一致するvideo_idなし→created_at最古を採用' if matches.empty?
+
+      'album.payloadに複数一致→created_at最古を採用'
+    end
+
+    def ytmusic_album_video_ids(album_id)
+      @ytmusic_album_video_ids[album_id] ||= begin
+        payload = YtmusicAlbum.unscoped.where(id: album_id).pick(:payload)
+        (payload&.dig('tracks') || []).filter_map { |track| track['video_id'] }.to_set
+      end
+    end
+
+    def build_loser(record)
+      Loser.new(id: record.id, created_at: record.created_at, reassigned_child_ids: [], cascaded_children: [])
+    end
+
+    # keeper 自身がグループ内で最も新しい行なら、マージ元は不要なので nil を返す。
+    def merge_source_id_for(target, records, keeper_id)
+      return nil unless target.merge_latest_attributes
+
+      newest = sort_by_keep(records, :newest).first
+      newest.id == keeper_id ? nil : newest.id
+    end
+
+    # 削除前に keeper へコピーする属性差分を、グループ横断で1回のクエリにまとめて計算する。
+    def assign_attribute_merges(target, groups)
+      pairs = groups.filter_map { |group| group.merge_source_id && [group.keeper_id, group.merge_source_id] }
+      return if pairs.empty?
+
+      records_by_id = target.model.unscoped.where(id: pairs.flatten.uniq).index_by(&:id)
+      mergeable_columns = target.model.column_names - NON_MERGEABLE_COLUMNS - target.unique_keys.map(&:to_s)
+
+      groups.each do |group|
+        next if group.merge_source_id.nil?
+
+        changes = attribute_changes(
+          keeper: records_by_id.fetch(group.keeper_id),
+          source: records_by_id.fetch(group.merge_source_id),
+          columns: mergeable_columns
+        )
+        group.attribute_merge = { source_id: group.merge_source_id, changes: } if changes.any?
+      end
+    end
+
+    def attribute_changes(keeper:, source:, columns:)
+      columns.each_with_object({}) do |column, changes|
+        new_value = source[column]
+        # コピー元が未設定の列は「情報がない」だけなので keeper の値を残す。
+        next if new_value.nil? || new_value == keeper[column]
+
+        changes[column] = { from: keeper[column], to: new_value }
+      end
+    end
+
+    # 重複グループに属する行だけを取得する（id / created_at / 一意キー＋keeper選定に必要な列）。
+    def duplicate_records(target)
+      model = target.model
+      unique_keys = target.unique_keys
+      key_tuples = model.unscoped.group(unique_keys).having(Arel.sql('COUNT(*) > 1')).pluck(*unique_keys)
+      # 一意キーが1列のときの pluck はスカラーを返すため、常にタプル（配列）に揃える。
+      # 例: ['a', 'b'] -> [['a'], ['b']]
+      key_tuples = key_tuples.zip if unique_keys.size == 1
+
+      key_tuples.each_slice(BATCH_SIZE).flat_map do |tuples|
+        model.unscoped.where(unique_keys => tuples).select(:id, :created_at, *unique_keys, *target.extra_columns).to_a
+      end
+    end
+
+    # keep が :oldest なら created_at 昇順、:newest なら降順。同着のタイブレークは常に id 昇順。
+    def sort_by_keep(records, keep)
+      direction = keep == :newest ? -1 : 1
+
+      records.sort do |a, b|
+        created_at_order = (a.created_at <=> b.created_at) * direction
+        created_at_order.zero? ? (a.id <=> b.id) : created_at_order
+      end
+    end
+
+    # loser に紐づく子を「keeper へ付け替える分」と「連鎖削除される分」に振り分ける。
+    # keeper が「既に持っている」一意キーの集合は、DBの実状態＋この実行中に付け替えを決めた分の両方で管理し、
+    # 複数の loser が同じ一意キーの子を持つ場合は最初の1件だけを付け替える。
+    def assign_child_plans(target, groups)
+      child = target.child
+      owner_ids = groups.flat_map { |group| [group.keeper_id, *group.losers.map(&:id)] }
+      rows_by_owner = child_rows_by_owner(child, owner_ids)
+
+      groups.each do |group|
+        taken_keys = rows_by_owner.fetch(group.keeper_id, []).to_set { |row| row[:key] }
+
+        group.losers.each do |loser|
+          rows_by_owner.fetch(loser.id, []).each do |row|
+            # keeper 側に同じ一意キーの子が既にある場合は付け替えず、
+            # loser の destroy! 時に dependent: :destroy で一緒に消えるに任せる。
+            if taken_keys.include?(row[:key])
+              loser.cascaded_children << CascadedChild.new(**row)
+            else
+              taken_keys << row[:key]
+              loser.reassigned_child_ids << row[:id]
+            end
+          end
+        end
+      end
+    end
+
+    def child_rows_by_owner(child, owner_ids)
+      return {} if owner_ids.empty?
+
+      columns = [:id, child.foreign_key, :created_at, *child.unique_keys]
+      rows = owner_ids.each_slice(BATCH_SIZE).flat_map do |ids|
+        child.model.unscoped.where(child.foreign_key => ids).order(:id).pluck(*columns)
+      end
+
+      rows.group_by { |row| row[1] }
+          .transform_values do |owned|
+            owned.map { |row| { id: row[0], created_at: row[2], key: child.unique_keys.zip(row[3..]).to_h } }
+          end
+    end
+
+    def key_of(record, unique_keys)
+      unique_keys.index_with { |column| record[column] }
+    end
+
+    # ------------------------------------------------------------------
+    # 安全装置
+    # ------------------------------------------------------------------
+
+    # 直接削除（loser自身）と連鎖削除（dependent: :destroy で消える子）の両方を安全装置に算入する。
+    def safety_violations(plans)
+      violations = total_deletion_violations(plans)
+
+      plans.each do |plan|
+        violations << deletion_ratio_violation(plan) if plan.deletion_ratio > max_ratio
+        violations << cascaded_ratio_violation(plan) if plan.target.child && plan.cascaded_ratio > max_ratio
+      end
+
+      violations
+    end
+
+    def total_deletion_violations(plans)
+      direct = plans.sum(&:deletion_count)
+      cascaded = plans.sum(&:cascaded_count)
+      total = direct + cascaded
+      return [] if total <= max_deletions
+
+      ["合計削除予定件数 直接 #{direct} 件 + 連鎖 #{cascaded} 件 = 合計 #{total} 件 が上限 #{max_deletions} 件を超えています"]
+    end
+
+    def deletion_ratio_violation(plan)
+      format(
+        '%<model>s の削除予定比率 %<ratio>.4f (%<deletions>d/%<total>d) が上限 %<max_ratio>.4f を超えています',
+        model: plan.target.model_name, ratio: plan.deletion_ratio,
+        deletions: plan.deletion_count, total: plan.total_count, max_ratio:
+      )
+    end
+
+    def cascaded_ratio_violation(plan)
+      format(
+        '%<child>s への連鎖削除予定比率 %<ratio>.4f (%<cascaded>d/%<total>d) が上限 %<max_ratio>.4f を超えています（親: %<parent>s）',
+        child: plan.target.child.model_name, ratio: plan.cascaded_ratio,
+        cascaded: plan.cascaded_count, total: plan.child_total_count,
+        max_ratio:, parent: plan.target.model_name
+      )
+    end
+
+    # ------------------------------------------------------------------
+    # 実行フェーズ（APPLY=1 かつ安全装置を通過したときのみ）
+    # ------------------------------------------------------------------
+
+    # 全テーブルを1トランザクションで処理する。途中で例外が出れば全体がロールバックされる。
+    # 戻り値は削除・マージの記録（削除ログにそのまま書き出す）。
+    def execute(plans)
+      log_rows = []
+
+      ActiveRecord::Base.transaction do
+        plans.each do |plan|
+          model = plan.target.model
+          child = plan.target.child
+
+          plan.groups.each do |group|
+            # loser を消す前に、最新行の属性を keeper へ取り込む。
+            apply_attribute_merge(model, group, log_rows) if group.attribute_merge
+
+            group.losers.each do |loser|
+              # 先に処理した親テーブルの dependent: :destroy で既に消えている場合がある。
+              # プランは実行前に一括作成しているため、ここで存在を確認してから削除する。
+              record = model.unscoped.find_by(id: loser.id)
+              next if record.nil?
+
+              reassign_children(child, loser.reassigned_child_ids, group.keeper_id) if child
+              record.destroy!
+              log_rows << direct_deletion_log_row(model, group, loser)
+              log_rows.concat(cascaded_deletion_log_rows(model, child, loser))
+            end
+          end
+        end
+      end
+
+      log_rows
+    end
+
+    def apply_attribute_merge(model, group, log_rows)
+      keeper = model.unscoped.find_by(id: group.keeper_id)
+      return if keeper.nil?
+
+      changes = group.attribute_merge[:changes]
+      keeper.update!(changes.transform_values { |change| change[:to] })
+      log_rows << {
+        type: 'merge',
+        table: model.table_name,
+        id: group.keeper_id,
+        source_id: group.attribute_merge[:source_id],
+        changes:
+      }
+    end
+
+    def reassign_children(child, child_ids, keeper_id)
+      return if child_ids.empty?
+
+      child.model.unscoped.where(id: child_ids).find_each do |record|
+        record.update!(child.foreign_key => keeper_id)
+      end
+    end
+
+    def direct_deletion_log_row(model, group, loser)
+      {
+        type: 'direct',
+        table: model.table_name,
+        id: loser.id,
+        key: group.key,
+        created_at: loser.created_at.iso8601,
+        kept_id: group.keeper_id
+      }
+    end
+
+    # dependent: :destroy で消えたはずの子を再クエリで確認し、実際に消えた分だけをログに残す。
+    def cascaded_deletion_log_rows(parent_model, child, loser)
+      return [] if child.nil? || loser.cascaded_children.empty?
+
+      surviving_ids = surviving_child_ids(child, loser.cascaded_children.map(&:id))
+
+      loser.cascaded_children.reject { |cascaded| surviving_ids.include?(cascaded.id) }.map do |cascaded|
+        {
+          type: 'cascaded',
+          table: child.model.table_name,
+          id: cascaded.id,
+          key: cascaded.key,
+          created_at: cascaded.created_at.iso8601,
+          cascaded_from: { table: parent_model.table_name, id: loser.id }
+        }
+      end
+    end
+
+    def surviving_child_ids(child, ids)
+      ids.each_slice(BATCH_SIZE).flat_map { |slice| child.model.unscoped.where(id: slice).pluck(:id) }.to_set
+    end
+
+    # 削除が正常にコミットされた場合のみ、JSON Lines形式で削除ログを残す。
+    def write_log(rows)
+      return nil if rows.empty?
+
+      path = Rails.root.join("log/dedupe_platform_records_#{Time.current.strftime('%Y%m%d%H%M%S')}.log")
+      FileUtils.mkdir_p(path.dirname)
+      File.open(path, 'a') do |file|
+        rows.each { |row| file.puts(row.to_json) }
+      end
+
+      path
+    end
+
+    # ------------------------------------------------------------------
+    # 出力
+    # ------------------------------------------------------------------
+
+    def print_header
+      newest_models = TARGETS.select { |target| target.keep == :newest }.map(&:model_name)
+      selector_models = TARGETS.select(&:keeper_selector).map(&:model_name)
+      merge_models = TARGETS.select(&:merge_latest_attributes).map(&:model_name)
+
+      out.puts '=' * 90
+      out.puts "プラットフォーム別テーブルの重複行クリーンアップ (#{apply? ? 'APPLY: 実削除します' : 'DRY-RUN: 削除しません'})"
+      out.puts '残す1行の基準: created_at 昇順 → id 昇順の先頭（最古）'
+      out.puts "  ただし #{newest_models.join(', ')} は created_at 降順 → id 昇順の先頭（最新）を残す（古い行の値が誤っているため）"
+      out.puts "  #{selector_models.join(', ')} は親アルバムの payload に載っている video_id を持つ行を優先する"
+      out.puts "  #{merge_models.join(', ')} は削除前にグループ内最新行の属性を keeper へマージする"
+      out.puts "安全装置: 合計削除上限 #{max_deletions} 件（直接削除＋連鎖削除の合計）"
+      out.puts "          テーブルごとの削除比率上限 #{max_ratio}（連鎖削除は子テーブル側の比率で別途判定）"
+      out.puts '=' * 90
+    end
+
+    def print_summary(plans)
+      out.puts format(SUMMARY_FORMAT, model: 'モデル', total: '総行数', groups: '重複グループ',
+                                      deletions: '削除予定', cascaded: '連鎖削除予定',
+                                      reassignments: '子付け替え予定', merges: '属性マージ予定', keep: '残す行')
+      plans.each do |plan|
+        out.puts format(
+          SUMMARY_FORMAT,
+          model: plan.target.model_name, total: plan.total_count, groups: plan.groups.size,
+          deletions: plan.deletion_count, cascaded: plan.cascaded_count,
+          reassignments: plan.reassignment_count, merges: plan.merge_count,
+          keep: keep_label(plan.target)
+        )
+      end
+
+      direct = plans.sum(&:deletion_count)
+      cascaded = plans.sum(&:cascaded_count)
+      out.puts format(
+        SUMMARY_FORMAT,
+        model: '合計', total: plans.sum(&:total_count), groups: plans.sum { |plan| plan.groups.size },
+        deletions: direct, cascaded:, reassignments: plans.sum(&:reassignment_count),
+        merges: plans.sum(&:merge_count), keep: '-'
+      )
+      out.puts "内訳: 直接削除 #{direct} 件 / 連鎖削除 #{cascaded} 件 / 合計 #{direct + cascaded} 件"
+    end
+
+    def keep_label(target)
+      return 'payload優先' if target.keeper_selector
+
+      target.keep == :newest ? '最新' : '最古'
+    end
+
+    def print_samples(plans)
+      out.puts ''
+      out.puts "重複グループのサンプル（各テーブル先頭 #{SAMPLE_SIZE} グループ / keeper の選定に payload を参照するテーブルは全グループ）"
+
+      plans.each do |plan|
+        next if plan.groups.empty?
+
+        out.puts "  #{plan.target.model_name}:"
+        sample_groups(plan).each { |group| out.puts "    #{sample_line(group)}" }
+      end
+    end
+
+    # keeper_selector を持つテーブルは「どの行を残すか」が created_at から読み取れないため、
+    # 選定結果を検証できるようにグループ数を絞らず全件表示する（数十グループ程度で収まる）。
+    def sample_groups(plan)
+      return plan.groups if plan.target.keeper_selector
+
+      plan.groups.first(SAMPLE_SIZE)
+    end
+
+    def sample_line(group)
+      key = group.key.map { |column, value| "#{column}=#{value}" }.join(', ')
+      keeper = "keeper=#{group.keeper_id}"
+      keeper += " (#{group.keeper_reason})" if group.keeper_reason
+      parts = [key, keeper, "losers=#{group.losers.map(&:id).join(', ')}"]
+      parts << merge_note(group.attribute_merge) if group.attribute_merge
+
+      parts.join(' / ')
+    end
+
+    def merge_note(attribute_merge)
+      "merge元=#{attribute_merge[:source_id]}(変更列: #{attribute_merge[:changes].keys.join(', ')})"
+    end
+
+    def print_deletion_counts(log_rows)
+      direct = log_rows.count { |row| row[:type] == 'direct' }
+      cascaded = log_rows.count { |row| row[:type] == 'cascaded' }
+
+      out.puts "削除完了: 直接削除 #{direct} 件 / 連鎖削除 #{cascaded} 件 / 合計 #{direct + cascaded} 件"
+      out.puts "属性マージ完了: #{log_rows.count { |row| row[:type] == 'merge' }} 件"
+    end
+
+    def print_violations(violations)
+      return if violations.empty?
+
+      out.puts ''
+      out.puts '安全装置に抵触しました:'
+      violations.each { |violation| out.puts "  - #{violation}" }
+    end
+
+    def print_abort_notice
+      if apply?
+        out.puts '中断しました。1行も削除していません。閾値を見直すか、MAX_DELETIONS / MAX_RATIO を明示的に指定してください。'
+      else
+        out.puts '（dry-run）APPLY=1 で実行した場合は上記の理由で中断し、1行も削除しませんでした。'
+      end
+    end
+
+    def build_result(plans:, violations:, log_rows:, log_path:)
+      direct_deletions = plans.sum(&:deletion_count)
+      cascaded_deletions = plans.sum(&:cascaded_count)
+
+      {
+        applied: apply? && violations.empty?,
+        aborted: violations.any?,
+        abort_reasons: violations,
+        total_rows: plans.sum(&:total_count),
+        total_direct_deletions: direct_deletions,
+        total_cascaded_deletions: cascaded_deletions,
+        total_deletions: direct_deletions + cascaded_deletions,
+        total_reassignments: plans.sum(&:reassignment_count),
+        deleted_count: log_rows.count { |row| row[:type] == 'direct' },
+        cascaded_deleted_count: log_rows.count { |row| row[:type] == 'cascaded' },
+        # 実行フェーズで実際にマージした件数。dry-run では常に0で、予定件数は tables[...][:merges] を見る。
+        total_merges: log_rows.count { |row| row[:type] == 'merge' },
+        log_path: log_path&.to_s,
+        tables: plans.to_h { |plan| [plan.target.model_name, table_result(plan)] }
+      }
+    end
+
+    def table_result(plan)
+      {
+        total_rows: plan.total_count,
+        duplicate_groups: plan.groups.size,
+        deletions: plan.deletion_count,
+        cascaded: plan.cascaded_count,
+        reassignments: plan.reassignment_count,
+        merges: plan.merge_count
+      }
+    end
+  end
+end

--- a/lib/tasks/dedupe.rake
+++ b/lib/tasks/dedupe.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc 'プラットフォーム別テーブルの重複行を除去する（既定はdry-run。APPLY=1で実削除。MAX_DELETIONS / MAX_RATIO で安全装置の閾値を上書き可能）'
+  task dedupe_platform_records: :environment do
+    Dedupe::PlatformRecords.new(
+      apply: ENV['APPLY'] == '1',
+      max_deletions: ENV.fetch('MAX_DELETIONS', Dedupe::PlatformRecords::DEFAULT_MAX_DELETIONS).to_i,
+      max_ratio: ENV.fetch('MAX_RATIO', Dedupe::PlatformRecords::DEFAULT_MAX_RATIO).to_f
+    ).run
+  end
+end

--- a/test/lib/dedupe/platform_records_test.rb
+++ b/test/lib/dedupe/platform_records_test.rb
@@ -1,0 +1,545 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Dedupe
+  class PlatformRecordsTest < ActiveSupport::TestCase
+    # テストデータはテーブル全体が重複だらけになるため、比率・件数の安全装置は明示的に緩めておき、
+    # 安全装置そのものを検証するテストだけ閾値を絞る。
+    test 'dry-runでは1行も削除しない' do
+      duplicates = create_apple_music_album_duplicates
+      result = nil
+
+      assert_no_difference ['AppleMusicAlbum.unscoped.count', 'AppleMusicTrack.unscoped.count'] do
+        result = run_dedupe(apply: false)
+      end
+
+      assert_not result[:applied]
+      assert_equal 0, result[:deleted_count]
+      assert_equal 1, result[:tables]['AppleMusicAlbum'][:deletions]
+      assert AppleMusicAlbum.unscoped.exists?(id: duplicates[:keeper].id)
+      assert AppleMusicAlbum.unscoped.exists?(id: duplicates[:loser].id)
+    end
+
+    test 'applyすると最古の行が残り重複行だけが削除される' do
+      album = create_album
+      apple_music_id = "dedupe-am-#{SecureRandom.hex(4)}"
+      oldest = middle = newest = nil
+      without_unique_index(:apple_music_albums, 'index_apple_music_albums_on_apple_music_id') do
+        oldest = create_apple_music_album(album:, apple_music_id:, created_at: 3.days.ago)
+        middle = create_apple_music_album(album:, apple_music_id:, created_at: 2.days.ago)
+        newest = create_apple_music_album(album:, apple_music_id:, created_at: 1.day.ago)
+      end
+
+      result = run_dedupe(apply: true)
+
+      assert result[:applied]
+      assert_equal 2, result[:deleted_count]
+      assert AppleMusicAlbum.unscoped.exists?(id: oldest.id)
+      assert_not AppleMusicAlbum.unscoped.exists?(id: middle.id)
+      assert_not AppleMusicAlbum.unscoped.exists?(id: newest.id)
+      assert_equal 1, AppleMusicAlbum.unscoped.where(apple_music_id:).count
+    end
+
+    test 'SpotifyTrackAudioFeatureは最新の行が残る' do
+      spotify_track = create_spotify_track_with_album
+      older = newer = nil
+      without_unique_index(:spotify_track_audio_features, 'index_spotify_track_audio_features_on_spotify_track_id') do
+        older = create_spotify_track_audio_feature(spotify_track:, tempo: 100.0, created_at: 2.days.ago)
+        newer = create_spotify_track_audio_feature(spotify_track:, tempo: 130.0, created_at: 1.day.ago)
+      end
+
+      run_dedupe(apply: true)
+
+      assert SpotifyTrackAudioFeature.exists?(id: newer.id)
+      assert_not SpotifyTrackAudioFeature.exists?(id: older.id)
+      assert_in_delta 130.0, SpotifyTrackAudioFeature.find(newer.id).tempo
+    end
+
+    test 'LineMusicTrackは最新の行が残る' do
+      line_music_album = create_line_music_album
+      track = create_track(line_music_album.album)
+      line_music_id = "dedupe-lm-#{SecureRandom.hex(4)}"
+      older = newer = nil
+      without_unique_index(:line_music_tracks, 'index_line_music_tracks_on_lm_album_id_and_lm_id') do
+        older = create_line_music_track(line_music_album:, track:, line_music_id:, created_at: 2.days.ago)
+        newer = create_line_music_track(line_music_album:, track:, line_music_id:, created_at: 1.day.ago)
+      end
+
+      run_dedupe(apply: true)
+
+      assert LineMusicTrack.unscoped.exists?(id: newer.id)
+      assert_not LineMusicTrack.unscoped.exists?(id: older.id)
+    end
+
+    test 'YtmusicTrackはalbum.payloadに載っているvideo_idの行が残る（最古が一致するケース）' do
+      fixture = create_ytmusic_track_duplicates(payload_video_ids: :older)
+
+      run_dedupe(apply: true)
+
+      assert YtmusicTrack.unscoped.exists?(id: fixture[:older].id)
+      assert_not YtmusicTrack.unscoped.exists?(id: fixture[:newer].id)
+    end
+
+    test 'YtmusicTrackはalbum.payloadに載っているvideo_idの行が残る（最新が一致するケース）' do
+      fixture = create_ytmusic_track_duplicates(payload_video_ids: :newer)
+
+      run_dedupe(apply: true)
+
+      assert YtmusicTrack.unscoped.exists?(id: fixture[:newer].id)
+      assert_not YtmusicTrack.unscoped.exists?(id: fixture[:older].id)
+    end
+
+    test 'YtmusicTrackはalbum.payloadに一致するvideo_idがない場合は最古が残る' do
+      fixture = create_ytmusic_track_duplicates(payload_video_ids: :none)
+
+      run_dedupe(apply: true)
+
+      assert YtmusicTrack.unscoped.exists?(id: fixture[:older].id)
+      assert_not YtmusicTrack.unscoped.exists?(id: fixture[:newer].id)
+    end
+
+    test 'YtmusicTrackはalbum.payloadに複数一致する場合は最古が残る' do
+      fixture = create_ytmusic_track_duplicates(payload_video_ids: :both)
+
+      run_dedupe(apply: true)
+
+      assert YtmusicTrack.unscoped.exists?(id: fixture[:older].id)
+      assert_not YtmusicTrack.unscoped.exists?(id: fixture[:newer].id)
+    end
+
+    test 'AppleMusicAlbumは削除前に最新の属性がkeeperへマージされる' do
+      fixture = create_apple_music_album_merge_target
+
+      run_dedupe(apply: true)
+      keeper = AppleMusicAlbum.unscoped.find(fixture[:keeper].id)
+
+      assert_equal 'New Name', keeper.name
+      assert_equal 'https://example.com/new', keeper.url
+      # loser 側が nil の列は「情報がない」だけなので keeper の値を残す。
+      assert_equal Date.new(2020, 1, 1), keeper.release_date
+    end
+
+    test 'AppleMusicAlbumの属性マージは削除ログに記録される' do
+      fixture = create_apple_music_album_merge_target
+
+      result = run_dedupe(apply: true)
+      rows = Pathname.new(result[:log_path]).readlines.map { |line| JSON.parse(line) }
+      merge_row = rows.find { |row| row['type'] == 'merge' && row['id'] == fixture[:keeper].id }
+
+      assert_equal 'apple_music_albums', merge_row['table']
+      assert_equal fixture[:loser].id, merge_row['source_id']
+      assert_equal({ 'from' => 'Old Name', 'to' => 'New Name' }, merge_row['changes']['name'])
+      assert_equal 1, result[:total_merges]
+      assert_equal 1, result[:tables]['AppleMusicAlbum'][:merges]
+    end
+
+    test 'YtmusicAlbumも削除前に最新の属性がkeeperへマージされる' do
+      album = create_album
+      browse_id = "dedupe-yta-#{SecureRandom.hex(4)}"
+      keeper = nil
+      without_unique_index(:ytmusic_albums, 'index_ytmusic_albums_on_album_id_and_browse_id') do
+        keeper = create_ytmusic_album(album:, browse_id:, name: 'Old Name', created_at: 2.days.ago)
+        create_ytmusic_album(album:, browse_id:, name: 'New Name', created_at: 1.day.ago)
+      end
+
+      result = run_dedupe(apply: true)
+
+      assert_equal 'New Name', YtmusicAlbum.unscoped.find(keeper.id).name
+      assert_equal 1, result[:tables]['YtmusicAlbum'][:merges]
+    end
+
+    test 'マージ対象外のテーブルでは最新の属性がkeeperへマージされない' do
+      album = create_album
+      apple_music_album = create_apple_music_album(album:, apple_music_id: "dedupe-am-#{SecureRandom.hex(4)}")
+      track = create_track(album)
+      keeper = nil
+      without_unique_index(:apple_music_tracks, 'index_apple_music_tracks_on_am_album_id_and_am_id') do
+        keeper = create_apple_music_track(apple_music_album:, track:, apple_music_id: 'track-merge',
+                                          name: 'Old Name', created_at: 2.days.ago)
+        create_apple_music_track(apple_music_album:, track:, apple_music_id: 'track-merge',
+                                 name: 'New Name', created_at: 1.day.ago)
+      end
+
+      result = run_dedupe(apply: true)
+      rows = Pathname.new(result[:log_path]).readlines.map { |line| JSON.parse(line) }
+
+      assert_equal 'Old Name', AppleMusicTrack.unscoped.find(keeper.id).name
+      assert_equal 0, result[:tables]['AppleMusicTrack'][:merges]
+      assert_empty(rows.select { |row| row['type'] == 'merge' && row['table'] == 'apple_music_tracks' })
+    end
+
+    test 'max_deletionsを超える場合はapplyでも中断して1行も削除しない' do
+      create_apple_music_album_duplicates(loser_count: 2)
+      result = nil
+
+      assert_no_difference 'AppleMusicAlbum.unscoped.count' do
+        result = run_dedupe(apply: true, max_deletions: 1)
+      end
+
+      assert result[:aborted]
+      assert_not result[:applied]
+      assert_equal 0, result[:deleted_count]
+      assert_equal 1, result[:abort_reasons].size
+    end
+
+    test 'max_ratioを超える場合はapplyでも中断して1行も削除しない' do
+      create_apple_music_album_duplicates
+      result = nil
+
+      assert_no_difference 'AppleMusicAlbum.unscoped.count' do
+        result = run_dedupe(apply: true, max_ratio: 0.05)
+      end
+
+      assert result[:aborted]
+      assert_equal 0, result[:deleted_count]
+    end
+
+    test '親の重複削除時に子はkeeperへ付け替えられ、同じ一意キーの子は削除される' do
+      fixture = create_apple_music_album_with_children
+
+      result = run_dedupe(apply: true)
+
+      assert_equal 1, result[:tables]['AppleMusicAlbum'][:reassignments]
+      assert_not AppleMusicAlbum.unscoped.exists?(id: fixture[:loser].id)
+      assert AppleMusicTrack.unscoped.exists?(id: fixture[:kept_child].id)
+      assert_not AppleMusicTrack.unscoped.exists?(id: fixture[:duplicated_child].id)
+      assert_equal fixture[:keeper].id, AppleMusicTrack.unscoped.find(fixture[:moved_child].id).apple_music_album_id
+    end
+
+    test '連鎖削除された子の件数が結果に含まれる' do
+      fixture = create_apple_music_album_with_children
+
+      result = run_dedupe(apply: true)
+
+      # duplicated_child だけが dependent: :destroy で道連れになる。
+      assert_equal 1, result[:tables]['AppleMusicAlbum'][:cascaded]
+      assert_equal 1, result[:cascaded_deleted_count]
+      assert_equal result[:total_direct_deletions] + result[:total_cascaded_deletions], result[:total_deletions]
+      assert_not AppleMusicTrack.unscoped.exists?(id: fixture[:duplicated_child].id)
+    end
+
+    test '削除ログには連鎖削除された子の行も記録される' do
+      fixture = create_apple_music_album_with_children
+
+      result = run_dedupe(apply: true)
+      rows = Pathname.new(result[:log_path]).readlines.map { |line| JSON.parse(line) }
+      cascaded_row = rows.find { |row| row['id'] == fixture[:duplicated_child].id }
+
+      assert_equal 'cascaded', cascaded_row['type']
+      assert_equal 'apple_music_tracks', cascaded_row['table']
+      assert_equal({ 'apple_music_id' => 'track-shared' }, cascaded_row['key'])
+      assert_equal({ 'table' => 'apple_music_albums', 'id' => fixture[:loser].id }, cascaded_row['cascaded_from'])
+      assert_not AppleMusicTrack.unscoped.exists?(id: cascaded_row['id'])
+    end
+
+    test '連鎖削除だけでmax_deletionsを超える場合はapplyでも中断して1行も削除しない' do
+      fixture = create_apple_music_album_with_children
+      result = nil
+
+      # 直接削除1件のみなら上限内だが、連鎖削除1件を合算すると上限を超える。
+      assert_no_difference ['AppleMusicAlbum.unscoped.count', 'AppleMusicTrack.unscoped.count'] do
+        result = run_dedupe(apply: true, max_deletions: 1)
+      end
+
+      assert result[:aborted]
+      assert_equal 0, result[:deleted_count]
+      assert_match(/直接 1 件 \+ 連鎖 1 件 = 合計 2 件/, result[:abort_reasons].first)
+      assert AppleMusicTrack.unscoped.exists?(id: fixture[:duplicated_child].id)
+    end
+
+    test '子テーブルへの連鎖削除比率が上限を超える場合はapplyでも中断する' do
+      fixture = create_apple_music_album_with_children
+      cascaded_ratio = 1.0 / AppleMusicTrack.unscoped.count
+      result = nil
+
+      # 子テーブル側の連鎖削除比率が独立した違反として報告されることを確かめる。
+      assert_no_difference ['AppleMusicAlbum.unscoped.count', 'AppleMusicTrack.unscoped.count'] do
+        result = run_dedupe(apply: true, max_ratio: cascaded_ratio / 2)
+      end
+
+      assert result[:aborted]
+      assert_equal 0, result[:deleted_count]
+      assert(result[:abort_reasons].any? { |reason| reason.include?('AppleMusicTrack への連鎖削除予定比率') })
+      assert AppleMusicTrack.unscoped.exists?(id: fixture[:duplicated_child].id)
+    end
+
+    test 'SpotifyTrackの重複削除時にaudio featureがkeeperへ付け替えられる' do
+      spotify_album = create_spotify_album
+      track = create_track(spotify_album.album)
+      spotify_id = "dedupe-sp-#{SecureRandom.hex(4)}"
+      keeper = loser = nil
+      without_unique_index(:spotify_tracks, 'index_spotify_tracks_on_spotify_album_id_and_spotify_id') do
+        keeper = create_spotify_track(spotify_album:, track:, spotify_id:, created_at: 2.days.ago)
+        loser = create_spotify_track(spotify_album:, track:, spotify_id:, created_at: 1.day.ago)
+      end
+      audio_feature = create_spotify_track_audio_feature(spotify_track: loser, tempo: 120.0, created_at: 1.day.ago)
+
+      result = run_dedupe(apply: true)
+
+      assert_equal 1, result[:tables]['SpotifyTrack'][:reassignments]
+      assert_not SpotifyTrack.unscoped.exists?(id: loser.id)
+      assert_equal keeper.id, SpotifyTrackAudioFeature.find(audio_feature.id).spotify_track_id
+    end
+
+    test '実削除後はJSON Lines形式の削除ログが出力される' do
+      duplicates = create_apple_music_album_duplicates
+
+      result = run_dedupe(apply: true)
+      log_path = Pathname.new(result[:log_path])
+
+      assert_predicate log_path, :exist?
+      # ログは追記式で、並列実行中の他テストの削除行も混ざりうるため、自テストの削除行を探して検証する。
+      deleted_row = log_path.readlines.map { |line| JSON.parse(line) }.find { |row| row['id'] == duplicates[:loser].id }
+
+      assert_equal 'apple_music_albums', deleted_row['table']
+      assert_equal duplicates[:keeper].id, deleted_row['kept_id']
+      assert_equal({ 'apple_music_id' => duplicates[:apple_music_id] }, deleted_row['key'])
+      assert_predicate deleted_row['created_at'], :present?
+    end
+
+    test '2回目の実行では削除対象が0件になる' do
+      create_apple_music_album_duplicates(loser_count: 2)
+
+      first_result = run_dedupe(apply: true)
+
+      assert_equal 2, first_result[:deleted_count]
+
+      second_result = nil
+
+      assert_no_difference 'AppleMusicAlbum.unscoped.count' do
+        second_result = run_dedupe(apply: true)
+      end
+
+      assert_equal 0, second_result[:total_deletions]
+      assert_equal 0, second_result[:deleted_count]
+      assert_nil second_result[:log_path]
+    end
+
+    private
+
+    def run_dedupe(apply:, max_deletions: 1000, max_ratio: 1.0)
+      PlatformRecords.new(apply:, max_deletions:, max_ratio:, out: StringIO.new).run
+    end
+
+    # unique index 下で重複行を意図的に作るためのテスト専用ヘルパー。
+    # PostgreSQLのDDLはトランザクション対応で、各テストはトランザクション内で実行されロールバックされるため、
+    # ここで外したindexはテスト終了時に自動的に復元される（明示的なteardownは不要）。
+    def without_unique_index(table, index_name)
+      ActiveRecord::Base.connection.remove_index(table, name: index_name)
+      yield
+    end
+
+    # keeper（最古）1件と loser を loser_count 件持つ AppleMusicAlbum の重複を作る。
+    def create_apple_music_album_duplicates(loser_count: 1)
+      album = create_album
+      apple_music_id = "dedupe-am-#{SecureRandom.hex(4)}"
+      keeper = nil
+      losers = []
+
+      without_unique_index(:apple_music_albums, 'index_apple_music_albums_on_apple_music_id') do
+        keeper = create_apple_music_album(album:, apple_music_id:, created_at: (loser_count + 1).days.ago)
+        losers = Array.new(loser_count) do |index|
+          create_apple_music_album(album:, apple_music_id:, created_at: (loser_count - index).days.ago)
+        end
+      end
+
+      { album:, apple_music_id:, keeper:, loser: losers.first, losers: }
+    end
+
+    # keeper / loser の AppleMusicAlbum に、付け替えられる子1件と連鎖削除される子1件をぶら下げる。
+    def create_apple_music_album_with_children
+      duplicates = create_apple_music_album_duplicates
+      keeper = duplicates[:keeper]
+      loser = duplicates[:loser]
+      album = duplicates[:album]
+
+      shared_track = create_track(album)
+      only_loser_track = create_track(album)
+
+      duplicates.merge(
+        kept_child: create_apple_music_track(apple_music_album: keeper, track: shared_track, apple_music_id: 'track-shared'),
+        duplicated_child: create_apple_music_track(apple_music_album: loser, track: shared_track, apple_music_id: 'track-shared'),
+        moved_child: create_apple_music_track(apple_music_album: loser, track: only_loser_track, apple_music_id: 'track-only-loser')
+      )
+    end
+
+    # keeper（最古）と loser（最新）で name / url / release_date の埋まり方が違う AppleMusicAlbum の重複を作る。
+    def create_apple_music_album_merge_target
+      album = create_album
+      apple_music_id = "dedupe-am-#{SecureRandom.hex(4)}"
+      keeper = loser = nil
+
+      without_unique_index(:apple_music_albums, 'index_apple_music_albums_on_apple_music_id') do
+        keeper = create_apple_music_album(album:, apple_music_id:, name: 'Old Name',
+                                          release_date: Date.new(2020, 1, 1), created_at: 2.days.ago)
+        loser = create_apple_music_album(album:, apple_music_id:, name: 'New Name',
+                                         url: 'https://example.com/new', created_at: 1.day.ago)
+      end
+
+      { album:, apple_music_id:, keeper:, loser: }
+    end
+
+    # 同じ track を指す YtmusicTrack の重複を作る。
+    # payload_video_ids で「親アルバムの payload にどちらの video_id を載せるか」を切り替える。
+    def create_ytmusic_track_duplicates(payload_video_ids:)
+      album = create_album
+      track = create_track(album)
+      older_video_id = "dedupe-video-old-#{SecureRandom.hex(4)}"
+      newer_video_id = "dedupe-video-new-#{SecureRandom.hex(4)}"
+      video_ids = {
+        older: [older_video_id], newer: [newer_video_id],
+        none: [], both: [older_video_id, newer_video_id]
+      }.fetch(payload_video_ids)
+      ytmusic_album = create_ytmusic_album(album:, video_ids:)
+      older = newer = nil
+
+      without_unique_index(:ytmusic_tracks, 'index_ytmusic_tracks_on_ytmusic_album_id_and_track_id') do
+        older = create_ytmusic_track(ytmusic_album:, track:, video_id: older_video_id, created_at: 2.days.ago)
+        newer = create_ytmusic_track(ytmusic_album:, track:, video_id: newer_video_id, created_at: 1.day.ago)
+      end
+
+      { ytmusic_album:, older:, newer: }
+    end
+
+    # 「どの行を残すか」は created_at で決まるため、Railsが自動設定した値を上書きして順序を固定する。
+    # rubocop:disable Rails/SkipsModelValidations
+    def overwrite_created_at(record, created_at)
+      record.update_columns(created_at:)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+
+    def create_album
+      Album.create!(jan_code: "dedupe-#{SecureRandom.hex(6)}")
+    end
+
+    def create_track(album)
+      Track.create!(album:, isrc: "JPDD#{SecureRandom.alphanumeric(8).upcase}")
+    end
+
+    # name / url / release_date などを上書きしたい場合は attributes に渡す。
+    def create_apple_music_album(album:, apple_music_id:, created_at: Time.current, **attributes)
+      AppleMusicAlbum.create!(
+        album:,
+        apple_music_id:,
+        name: 'Dedupe Apple Music Album',
+        label: Album::TOUHOU_MUSIC_LABEL,
+        **attributes
+      ).tap { |record| overwrite_created_at(record, created_at) }
+    end
+
+    def create_apple_music_track(apple_music_album:, track:, apple_music_id:, name: 'Dedupe Apple Music Track',
+                                 created_at: Time.current)
+      AppleMusicTrack.create!(
+        album: apple_music_album.album,
+        apple_music_album:,
+        track:,
+        apple_music_id:,
+        name:,
+        label: Album::TOUHOU_MUSIC_LABEL
+      ).tap { |record| overwrite_created_at(record, created_at) }
+    end
+
+    def create_line_music_album
+      album = create_album
+      LineMusicAlbum.create!(
+        album:,
+        line_music_id: "dedupe-lma-#{SecureRandom.hex(4)}",
+        name: 'Dedupe LINE MUSIC Album'
+      )
+    end
+
+    def create_line_music_track(line_music_album:, track:, line_music_id:, created_at: Time.current)
+      LineMusicTrack.create!(
+        album: line_music_album.album,
+        line_music_album:,
+        track:,
+        line_music_id:,
+        name: 'Dedupe LINE MUSIC Track',
+        disc_number: 1,
+        track_number: 1
+      ).tap { |record| overwrite_created_at(record, created_at) }
+    end
+
+    def create_ytmusic_album(album:, browse_id: nil, name: 'Dedupe YouTube Music Album', video_ids: [],
+                             created_at: Time.current)
+      YtmusicAlbum.create!(
+        album:,
+        browse_id: browse_id || "dedupe-yta-#{SecureRandom.hex(4)}",
+        name:,
+        payload: { 'tracks' => video_ids.map { |video_id| { 'video_id' => video_id } } }
+      ).tap { |record| overwrite_created_at(record, created_at) }
+    end
+
+    def create_ytmusic_track(ytmusic_album:, track:, video_id:, created_at: Time.current)
+      YtmusicTrack.create!(
+        album: ytmusic_album.album,
+        ytmusic_album:,
+        track:,
+        video_id:,
+        playlist_id: "dedupe-ytpl-#{SecureRandom.hex(4)}",
+        name: 'Dedupe YouTube Music Track',
+        track_number: 1
+      ).tap { |record| overwrite_created_at(record, created_at) }
+    end
+
+    def create_spotify_album
+      album = create_album
+      SpotifyAlbum.create!(
+        album:,
+        spotify_id: "dedupe-spa-#{SecureRandom.hex(4)}",
+        album_type: 'album',
+        name: 'Dedupe Spotify Album',
+        label: Album::TOUHOU_MUSIC_LABEL,
+        total_tracks: 1,
+        active: true,
+        payload: {}
+      )
+    end
+
+    def create_spotify_track(spotify_album:, track:, spotify_id:, created_at: Time.current)
+      SpotifyTrack.create!(
+        album: spotify_album.album,
+        spotify_album:,
+        track:,
+        spotify_id:,
+        name: 'Dedupe Spotify Track',
+        label: Album::TOUHOU_MUSIC_LABEL,
+        disc_number: 1,
+        track_number: 1,
+        duration_ms: 180_000,
+        payload: {}
+      ).tap { |record| overwrite_created_at(record, created_at) }
+    end
+
+    def create_spotify_track_with_album
+      spotify_album = create_spotify_album
+      create_spotify_track(
+        spotify_album:,
+        track: create_track(spotify_album.album),
+        spotify_id: "dedupe-sp-#{SecureRandom.hex(4)}"
+      )
+    end
+
+    def create_spotify_track_audio_feature(spotify_track:, tempo:, created_at: Time.current)
+      SpotifyTrackAudioFeature.create!(
+        track: spotify_track.track,
+        spotify_track:,
+        spotify_id: spotify_track.spotify_id,
+        acousticness: 0.1,
+        danceability: 0.2,
+        duration_ms: 180_000,
+        energy: 0.3,
+        instrumentalness: 0.4,
+        key: 1,
+        liveness: 0.5,
+        loudness: -5.0,
+        mode: 1,
+        speechiness: 0.6,
+        tempo:,
+        time_signature: 4,
+        valence: 0.7
+      ).tap { |record| overwrite_created_at(record, created_at) }
+    end
+  end
+end

--- a/test/lib/tasks/dedupe_test.rb
+++ b/test/lib/tasks/dedupe_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rake'
+
+class DedupeTaskTest < ActiveSupport::TestCase
+  Rake::Task.define_task(:environment)
+  load Rails.root.join('lib/tasks/dedupe.rake')
+
+  setup do
+    Rake::Task['db:dedupe_platform_records'].reenable
+  end
+
+  test 'APPLY未指定の実行はdry-runとなりレコードを削除しない' do
+    create_apple_music_album_duplicates
+
+    output, = capture_io do
+      assert_no_difference 'AppleMusicAlbum.unscoped.count' do
+        Rake::Task['db:dedupe_platform_records'].invoke
+      end
+    end
+
+    assert_match 'DRY-RUN', output
+    assert_match 'AppleMusicAlbum', output
+    assert_match '連鎖削除予定', output
+  end
+
+  private
+
+  # unique index 下で重複行を意図的に作るためのテスト専用ヘルパー。
+  # PostgreSQLのDDLはトランザクション対応で、各テストはトランザクション内で実行されロールバックされるため、
+  # ここで外したindexはテスト終了時に自動的に復元される（明示的なteardownは不要）。
+  def create_apple_music_album_duplicates
+    album = Album.create!(jan_code: "dedupe-task-#{SecureRandom.hex(6)}")
+    apple_music_id = "dedupe-task-am-#{SecureRandom.hex(4)}"
+
+    ActiveRecord::Base.connection.remove_index(:apple_music_albums, name: 'index_apple_music_albums_on_apple_music_id')
+    2.times do
+      AppleMusicAlbum.create!(album:, apple_music_id:, name: 'Dedupe Task Album', label: Album::TOUHOU_MUSIC_LABEL)
+    end
+  end
+end

--- a/test/models/apple_music_album_test.rb
+++ b/test/models/apple_music_album_test.rb
@@ -3,7 +3,66 @@
 require 'test_helper'
 
 class AppleMusicAlbumTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  AppleMusicApiAlbum = Struct.new(
+    :id,
+    :name,
+    :record_label,
+    :url,
+    :release_date,
+    :track_count,
+    :upc,
+    keyword_init: true
+  ) do
+    def as_json(*)
+      { 'id' => id, 'name' => name }
+    end
+  end
+
+  test 'save_album reuses the row with the same apple_music_id when other attributes differ' do
+    jan_code = "apple-music-album-#{SecureRandom.hex(4)}"
+    apple_music_id = "am-album-#{SecureRandom.hex(4)}"
+
+    assert_difference -> { AppleMusicAlbum.unscoped.count }, 1 do
+      AppleMusicAlbum.save_album(build_api_album(id: apple_music_id, upc: jan_code, name: '幻想郷スタイル'))
+    end
+
+    assert_no_difference -> { AppleMusicAlbum.unscoped.count } do
+      @apple_music_album = AppleMusicAlbum.save_album(
+        build_api_album(
+          id: apple_music_id,
+          upc: jan_code,
+          name: '幻想郷スタイル (Remastered)',
+          track_count: 12
+        )
+      )
+    end
+
+    assert_equal '幻想郷スタイル (Remastered)', @apple_music_album.reload.name
+    assert_equal 12, @apple_music_album.total_tracks
+  end
+
+  test 'save_album skips albums that are not distributed by the Touhou music label' do
+    api_album = build_api_album(
+      id: "am-album-#{SecureRandom.hex(4)}",
+      upc: "apple-music-album-other-label-#{SecureRandom.hex(4)}",
+      record_label: 'Other Label'
+    )
+
+    assert_no_difference -> { AppleMusicAlbum.unscoped.count } do
+      assert_nil AppleMusicAlbum.save_album(api_album)
+    end
+  end
+
+  private
+
+  def build_api_album(**attributes)
+    AppleMusicApiAlbum.new(
+      name: 'Apple Music Album',
+      record_label: ::Album::TOUHOU_MUSIC_LABEL,
+      url: 'https://music.apple.com/jp/album/test',
+      release_date: Date.new(2026, 1, 1),
+      track_count: 10,
+      **attributes
+    )
+  end
 end

--- a/test/models/apple_music_artist_test.rb
+++ b/test/models/apple_music_artist_test.rb
@@ -3,7 +3,38 @@
 require 'test_helper'
 
 class AppleMusicArtistTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  AppleMusicApiArtist = Struct.new(:id, :name, :url, keyword_init: true) do
+    def as_json(*)
+      { 'id' => id, 'name' => name }
+    end
+  end
+
+  test 'save_artist reuses the row with the same apple_music_id when other attributes differ' do
+    apple_music_id = "am-artist-#{SecureRandom.hex(4)}"
+
+    assert_difference -> { AppleMusicArtist.unscoped.count }, 1 do
+      AppleMusicArtist.save_artist(build_api_artist(id: apple_music_id, name: '幽閉サテライト'))
+    end
+
+    assert_no_difference -> { AppleMusicArtist.unscoped.count } do
+      AppleMusicArtist.save_artist(
+        build_api_artist(
+          id: apple_music_id,
+          name: '幽閉サテライト (Yuuhei Satellite)',
+          url: 'https://music.apple.com/jp/artist/renamed'
+        )
+      )
+    end
+
+    apple_music_artist = AppleMusicArtist.unscoped.find_by!(apple_music_id:)
+
+    assert_equal '幽閉サテライト (Yuuhei Satellite)', apple_music_artist.name
+    assert_equal 'https://music.apple.com/jp/artist/renamed', apple_music_artist.url
+  end
+
+  private
+
+  def build_api_artist(**attributes)
+    AppleMusicApiArtist.new(url: 'https://music.apple.com/jp/artist/test', **attributes)
+  end
 end

--- a/test/models/apple_music_track_test.rb
+++ b/test/models/apple_music_track_test.rb
@@ -3,7 +3,89 @@
 require 'test_helper'
 
 class AppleMusicTrackTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  AppleMusicApiTrack = Struct.new(
+    :id,
+    :isrc,
+    :name,
+    :artist_name,
+    :composer_name,
+    :url,
+    :release_date,
+    :disc_number,
+    :track_number,
+    :duration_in_millis,
+    keyword_init: true
+  ) do
+    def as_json(*)
+      { 'id' => id, 'name' => name }
+    end
+  end
+
+  # 同じトラックでも Apple Music 側で括弧が全角/半角に揺れることがあり、
+  # 以前は表記が変わるたびに新しい行が作られていた。
+  test 'save_track reuses the row when only the title notation changes' do
+    apple_music_album = create_apple_music_album
+    apple_music_id = "am-track-#{SecureRandom.hex(4)}"
+    isrc = "ISRC#{SecureRandom.hex(4)}"
+
+    assert_difference -> { AppleMusicTrack.unscoped.count }, 1 do
+      AppleMusicTrack.save_track(
+        apple_music_album,
+        build_api_track(id: apple_music_id, isrc:, name: 'silently arity（SA ver.）')
+      )
+    end
+
+    assert_no_difference -> { AppleMusicTrack.unscoped.count } do
+      @apple_music_track = AppleMusicTrack.save_track(
+        apple_music_album,
+        build_api_track(id: apple_music_id, isrc:, name: 'silently arity(SA ver.)', duration_in_millis: 254_000)
+      )
+    end
+
+    assert_equal 'silently arity(SA ver.)', @apple_music_track.reload.name
+    assert_equal 254_000, @apple_music_track.duration_ms
+  end
+
+  test 'save_track creates separate rows for different Apple Music tracks in the same album' do
+    apple_music_album = create_apple_music_album
+
+    assert_difference -> { AppleMusicTrack.unscoped.count }, 2 do
+      AppleMusicTrack.save_track(
+        apple_music_album,
+        build_api_track(id: "am-track-#{SecureRandom.hex(4)}", isrc: "ISRC#{SecureRandom.hex(4)}", track_number: 1)
+      )
+      AppleMusicTrack.save_track(
+        apple_music_album,
+        build_api_track(id: "am-track-#{SecureRandom.hex(4)}", isrc: "ISRC#{SecureRandom.hex(4)}", track_number: 2)
+      )
+    end
+  end
+
+  private
+
+  def create_apple_music_album
+    album = Album.create!(jan_code: "apple-music-track-#{SecureRandom.hex(4)}")
+
+    AppleMusicAlbum.create!(
+      album:,
+      apple_music_id: "am-album-#{SecureRandom.hex(4)}",
+      name: 'Apple Music Album',
+      label: ::Album::TOUHOU_MUSIC_LABEL,
+      payload: {}
+    )
+  end
+
+  def build_api_track(**attributes)
+    AppleMusicApiTrack.new(
+      name: 'Apple Music Track',
+      artist_name: '幽閉サテライト',
+      composer_name: 'HiZuMi',
+      url: 'https://music.apple.com/jp/song/test',
+      release_date: Date.new(2026, 1, 1),
+      disc_number: 1,
+      track_number: 1,
+      duration_in_millis: 240_000,
+      **attributes
+    )
+  end
 end

--- a/test/models/line_music_track_test.rb
+++ b/test/models/line_music_track_test.rb
@@ -3,6 +3,40 @@
 require 'test_helper'
 
 class LineMusicTrackTest < ActiveSupport::TestCase
+  LineMusicApiTrack = Struct.new(:track_id, :track_title, :disc_number, :track_number, keyword_init: true) do
+    def as_json(*)
+      { 'track_id' => track_id, 'track_title' => track_title, 'artists' => [] }
+    end
+  end
+
+  test 'save_track reuses the row with the same line_music_album_id and line_music_id when other attributes differ' do
+    album, track, line_music_album = create_line_music_album
+    line_music_id = "lm-track-#{SecureRandom.hex(4)}"
+
+    assert_difference -> { LineMusicTrack.unscoped.count }, 1 do
+      LineMusicTrack.save_track(
+        album.id,
+        track.id,
+        line_music_album,
+        build_api_track(track_id: line_music_id, track_title: '妖々跋扈 ~ Who done it!')
+      )
+    end
+
+    assert_no_difference -> { LineMusicTrack.unscoped.count } do
+      LineMusicTrack.save_track(
+        album.id,
+        track.id,
+        line_music_album,
+        build_api_track(track_id: line_music_id, track_title: '妖々跋扈 ~ Who done it', track_number: 4)
+      )
+    end
+
+    line_music_track = LineMusicTrack.unscoped.find_by!(line_music_album_id: line_music_album.id, line_music_id:)
+
+    assert_equal '妖々跋扈 ~ Who done it', line_music_track.name
+    assert_equal 4, line_music_track.track_number
+  end
+
   test 'reports progress while fetching LINE MUSIC tracks' do
     album = Album.create!(jan_code: "line-music-track-progress-#{SecureRandom.hex(4)}")
     updates = []
@@ -25,6 +59,25 @@ class LineMusicTrackTest < ActiveSupport::TestCase
   end
 
   private
+
+  def create_line_music_album
+    jan_code = "line-music-track-save-#{SecureRandom.hex(4)}"
+    album = Album.create!(jan_code:)
+    track = Track.create!(jan_code:, isrc: "ISRC#{SecureRandom.hex(4)}")
+    line_music_album = LineMusicAlbum.create!(
+      album:,
+      line_music_id: "lm-album-#{SecureRandom.hex(4)}",
+      name: 'LINE MUSIC Album',
+      total_tracks: 2,
+      payload: {}
+    )
+
+    [album, track, line_music_album]
+  end
+
+  def build_api_track(**attributes)
+    LineMusicApiTrack.new(track_title: 'LINE MUSIC Track', disc_number: 1, track_number: 1, **attributes)
+  end
 
   def with_line_music_track_processor(processor)
     singleton_class = LineMusicTrack.singleton_class

--- a/test/models/spotify_artist_test.rb
+++ b/test/models/spotify_artist_test.rb
@@ -3,7 +3,42 @@
 require 'test_helper'
 
 class SpotifyArtistTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  SpotifyApiArtist = Struct.new(:id, :name, :external_urls, :followers, keyword_init: true) do
+    def as_json(*)
+      { 'id' => id, 'name' => name }
+    end
+  end
+
+  test 'save_artist reuses the row with the same spotify_id when other attributes differ' do
+    spotify_id = "spotify-artist-#{SecureRandom.hex(4)}"
+
+    assert_difference -> { SpotifyArtist.unscoped.count }, 1 do
+      SpotifyArtist.save_artist(build_api_artist(id: spotify_id, name: 'ZYTOKINE', follower_count: 100))
+    end
+
+    assert_no_difference -> { SpotifyArtist.unscoped.count } do
+      @spotify_artist = SpotifyArtist.save_artist(
+        build_api_artist(id: spotify_id, name: 'ZYTOKINE / 隣人', follower_count: 250)
+      )
+    end
+
+    assert_equal 'ZYTOKINE / 隣人', @spotify_artist.reload.name
+    assert_equal 250, @spotify_artist.follower_count
+  end
+
+  test 'save_artist returns nil for a blank artist' do
+    assert_no_difference -> { SpotifyArtist.unscoped.count } do
+      assert_nil SpotifyArtist.save_artist(nil)
+    end
+  end
+
+  private
+
+  def build_api_artist(follower_count:, **attributes)
+    SpotifyApiArtist.new(
+      external_urls: { 'spotify' => 'https://open.spotify.com/artist/test' },
+      followers: { 'total' => follower_count },
+      **attributes
+    )
+  end
 end

--- a/test/models/spotify_track_audio_feature_test.rb
+++ b/test/models/spotify_track_audio_feature_test.rb
@@ -3,7 +3,99 @@
 require 'test_helper'
 
 class SpotifyTrackAudioFeatureTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  SpotifyApiAudioFeatures = Struct.new(
+    :acousticness,
+    :danceability,
+    :duration_ms,
+    :energy,
+    :instrumentalness,
+    :key,
+    :liveness,
+    :loudness,
+    :mode,
+    :speechiness,
+    :tempo,
+    :time_signature,
+    :valence,
+    :analysis_url,
+    keyword_init: true
+  ) do
+    def as_json(*)
+      { 'tempo' => tempo, 'analysis_url' => analysis_url }
+    end
+  end
+
+  # Spotify の再解析で tempo などが変わっても行は増やさず更新する。
+  test 'save_audio_features reuses the row with the same spotify_track_id when the analysis changes' do
+    spotify_track = create_spotify_track
+
+    assert_difference -> { SpotifyTrackAudioFeature.unscoped.count }, 1 do
+      SpotifyTrackAudioFeature.save_audio_features(spotify_track, build_audio_features(tempo: 174.0))
+    end
+
+    assert_no_difference -> { SpotifyTrackAudioFeature.unscoped.count } do
+      @audio_feature = SpotifyTrackAudioFeature.save_audio_features(
+        spotify_track,
+        build_audio_features(tempo: 87.5, energy: 0.42)
+      )
+    end
+
+    assert_in_delta 87.5, @audio_feature.reload.tempo
+    assert_in_delta 0.42, @audio_feature.energy
+  end
+
+  test 'save_audio_features returns nil for blank arguments' do
+    spotify_track = create_spotify_track
+
+    assert_no_difference -> { SpotifyTrackAudioFeature.unscoped.count } do
+      assert_nil SpotifyTrackAudioFeature.save_audio_features(nil, build_audio_features)
+      assert_nil SpotifyTrackAudioFeature.save_audio_features(spotify_track, nil)
+    end
+  end
+
+  private
+
+  def create_spotify_track
+    jan_code = "spotify-audio-feature-#{SecureRandom.hex(4)}"
+    album = Album.create!(jan_code:)
+    track = Track.create!(jan_code:, isrc: "ISRC#{SecureRandom.hex(4)}")
+    spotify_album = SpotifyAlbum.create!(
+      album:,
+      spotify_id: "spotify-album-#{SecureRandom.hex(4)}",
+      album_type: 'album',
+      name: 'Spotify Album',
+      label: ::Album::TOUHOU_MUSIC_LABEL,
+      payload: {}
+    )
+
+    SpotifyTrack.create!(
+      album:,
+      track:,
+      spotify_album:,
+      spotify_id: "spotify-track-#{SecureRandom.hex(4)}",
+      name: 'Spotify Track',
+      label: ::Album::TOUHOU_MUSIC_LABEL,
+      payload: {}
+    )
+  end
+
+  def build_audio_features(**attributes)
+    SpotifyApiAudioFeatures.new(
+      acousticness: 0.1,
+      danceability: 0.2,
+      duration_ms: 240_000,
+      energy: 0.3,
+      instrumentalness: 0.4,
+      key: 5,
+      liveness: 0.6,
+      loudness: -7.5,
+      mode: 1,
+      speechiness: 0.05,
+      tempo: 174.0,
+      time_signature: 4,
+      valence: 0.8,
+      analysis_url: 'https://api.spotify.com/v1/audio-analysis/test',
+      **attributes
+    )
+  end
 end

--- a/test/models/spotify_track_test.rb
+++ b/test/models/spotify_track_test.rb
@@ -3,7 +3,75 @@
 require 'test_helper'
 
 class SpotifyTrackTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  SpotifyApiTrack = Struct.new(
+    :id,
+    :name,
+    :external_ids,
+    :external_urls,
+    :disc_number,
+    :track_number,
+    :duration_ms,
+    keyword_init: true
+  ) do
+    def as_json(*)
+      { 'id' => id, 'name' => name, 'artists' => [] }
+    end
+  end
+
+  test 'save_track reuses the row with the same spotify_album_id and spotify_id when other attributes differ' do
+    spotify_album = create_spotify_album
+    spotify_id = "spotify-track-#{SecureRandom.hex(4)}"
+    isrc = "ISRC#{SecureRandom.hex(4)}"
+
+    assert_difference -> { SpotifyTrack.unscoped.count }, 1 do
+      SpotifyTrack.save_track(spotify_album, build_api_track(id: spotify_id, isrc:, name: '色は匂へど 散りぬるを'))
+    end
+
+    assert_no_difference -> { SpotifyTrack.unscoped.count } do
+      @spotify_track = SpotifyTrack.save_track(
+        spotify_album,
+        build_api_track(id: spotify_id, isrc:, name: '色は匂へど散りぬるを', track_number: 3)
+      )
+    end
+
+    assert_equal '色は匂へど散りぬるを', @spotify_track.reload.name
+    assert_equal 3, @spotify_track.track_number
+  end
+
+  test 'save_track returns nil for blank arguments' do
+    spotify_album = create_spotify_album
+
+    assert_no_difference -> { SpotifyTrack.unscoped.count } do
+      assert_nil SpotifyTrack.save_track(nil, build_api_track(id: 'x', isrc: 'y'))
+      assert_nil SpotifyTrack.save_track(spotify_album, nil)
+    end
+  end
+
+  private
+
+  def create_spotify_album
+    album = Album.create!(jan_code: "spotify-track-#{SecureRandom.hex(4)}")
+
+    SpotifyAlbum.create!(
+      album:,
+      spotify_id: "spotify-album-#{SecureRandom.hex(4)}",
+      album_type: 'album',
+      name: 'Spotify Album',
+      label: ::Album::TOUHOU_MUSIC_LABEL,
+      release_date: Date.new(2026, 1, 1),
+      payload: {}
+    )
+  end
+
+  def build_api_track(isrc:, **attributes)
+    SpotifyApiTrack.new(
+      name: 'Spotify Track',
+      external_ids: { 'isrc' => isrc },
+      external_urls: { 'spotify' => 'https://open.spotify.com/track/test' },
+      disc_number: 1,
+      track_number: 1,
+      duration_ms: 240_000,
+      **attributes
+    )
+  end
 end

--- a/test/models/ytmusic_album_test.rb
+++ b/test/models/ytmusic_album_test.rb
@@ -3,6 +3,33 @@
 require 'test_helper'
 
 class YtmusicAlbumTest < ActiveSupport::TestCase
+  YtmusicApiAlbum = Struct.new(:title, :playlist_url, :track_total_count, :year, keyword_init: true) do
+    def as_json(*)
+      { 'title' => title, 'year' => year, 'artists' => [] }
+    end
+  end
+
+  test 'save_album reuses the row with the same album_id and browse_id when other attributes differ' do
+    album = Album.create!(jan_code: "ytmusic-album-save-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+
+    assert_difference -> { YtmusicAlbum.unscoped.count }, 1 do
+      YtmusicAlbum.save_album(album.id, browse_id, build_api_album(title: '東方猫鍵盤'))
+    end
+
+    assert_no_difference -> { YtmusicAlbum.unscoped.count } do
+      @ytmusic_album = YtmusicAlbum.save_album(
+        album.id,
+        browse_id,
+        build_api_album(title: '東方猫鍵盤 9', track_total_count: 12)
+      )
+    end
+
+    assert_equal '東方猫鍵盤 9', @ytmusic_album.reload.name
+    assert_equal 12, @ytmusic_album.total_tracks
+    assert_equal "https://music.youtube.com/browse/#{browse_id}", @ytmusic_album.url
+  end
+
   test 'reports progress while fetching YouTube Music albums' do
     album = Album.create!(jan_code: "ytmusic-progress-#{SecureRandom.hex(4)}")
     updates = []
@@ -27,6 +54,16 @@ class YtmusicAlbumTest < ActiveSupport::TestCase
   end
 
   private
+
+  def build_api_album(**attributes)
+    YtmusicApiAlbum.new(
+      title: 'YouTube Music Album',
+      playlist_url: 'https://music.youtube.com/playlist?list=test',
+      track_total_count: 10,
+      year: '2026',
+      **attributes
+    )
+  end
 
   def with_ytmusic_album_processors(processor)
     singleton_class = YtmusicAlbum.singleton_class

--- a/test/models/ytmusic_track_test.rb
+++ b/test/models/ytmusic_track_test.rb
@@ -3,6 +3,40 @@
 require 'test_helper'
 
 class YtmusicTrackTest < ActiveSupport::TestCase
+  VIDEO_ID = 'video-bad-apple'
+  PLAYLIST_ID = 'playlist-bad-apple'
+
+  test 'save_track reuses the row with the same ytmusic_album_id and track_id when other attributes differ' do
+    album, track, ytmusic_album = create_ytmusic_album
+    payload_track = build_payload_track(title: 'Bad Apple!! feat. nomico')
+    ytmusic_album.update!(payload: { 'tracks' => [payload_track] })
+
+    assert_difference -> { YtmusicTrack.unscoped.count }, 1 do
+      YtmusicTrack.save_track(album.id, track.id, ytmusic_album, payload_track)
+    end
+
+    renamed_track = build_payload_track(title: 'Bad Apple!! feat.nomico')
+    ytmusic_album.update!(payload: { 'tracks' => [renamed_track] })
+
+    assert_no_difference -> { YtmusicTrack.unscoped.count } do
+      YtmusicTrack.save_track(album.id, track.id, ytmusic_album, renamed_track)
+    end
+
+    ytmusic_track = YtmusicTrack.unscoped.find_by!(ytmusic_album_id: ytmusic_album.id, track_id: track.id)
+
+    assert_equal 'Bad Apple!! feat.nomico', ytmusic_track.name
+  end
+
+  test 'save_track skips a payload track whose url lacks the video id' do
+    album, track, ytmusic_album = create_ytmusic_album
+    payload_track = build_payload_track(url: 'https://music.youtube.com/watch?v=other')
+    ytmusic_album.update!(payload: { 'tracks' => [payload_track] })
+
+    assert_no_difference -> { YtmusicTrack.unscoped.count } do
+      assert_nil YtmusicTrack.save_track(album.id, track.id, ytmusic_album, payload_track)
+    end
+  end
+
   test 'reports progress while fetching YouTube Music tracks' do
     album = Album.create!(jan_code: "ytmusic-track-progress-#{SecureRandom.hex(4)}")
     updates = []
@@ -25,6 +59,31 @@ class YtmusicTrackTest < ActiveSupport::TestCase
   end
 
   private
+
+  def create_ytmusic_album
+    jan_code = "ytmusic-track-save-#{SecureRandom.hex(4)}"
+    album = Album.create!(jan_code:)
+    track = Track.create!(jan_code:, isrc: "ISRC#{SecureRandom.hex(4)}")
+    ytmusic_album = YtmusicAlbum.create!(
+      album:,
+      browse_id: "MPREb_#{SecureRandom.hex(4)}",
+      name: 'YouTube Music Album',
+      total_tracks: 1,
+      payload: {}
+    )
+
+    [album, track, ytmusic_album]
+  end
+
+  def build_payload_track(**attributes)
+    {
+      'title' => 'YouTube Music Track',
+      'url' => "https://music.youtube.com/watch?v=#{VIDEO_ID}&list=#{PLAYLIST_ID}",
+      'video_id' => VIDEO_ID,
+      'playlist_id' => PLAYLIST_ID,
+      'track_number' => 1
+    }.merge(attributes.transform_keys(&:to_s))
+  end
 
   def with_ytmusic_track_processor(processor)
     singleton_class = YtmusicTrack.singleton_class


### PR DESCRIPTION
## 概要

各配信プラットフォームのテーブルに重複レコードが蓄積していた問題を、原因の修正・既存データの除去・DB制約の追加の3段階で解決します。

`find_or_create_by!` に一意キー以外の属性まで渡していたため、曲名の表記ゆれ（`silently arity（SA ver.）` ↔ `silently arity(SA ver.)`）や `payload` の変化だけで新規行が作られていました。

## 変更内容

**1. 止血** — 9モデルの `find_or_create_by!` を一意キーのみに絞り、残りの属性を `update!` に集約。NOT NULL 列はブロック形式で新規作成時に充足。各モデルに「属性違いで2回 save しても行が増えない」回帰テストを追加

**2. 既存重複の除去** — rake タスク `db:dedupe_platform_records` を新設（dry-run 既定 / `APPLY=1` で実行 / 削除件数上限 `MAX_DELETIONS=1500` / 比率アボート `MAX_RATIO=0.05` / 連鎖削除の算入 / トランザクション / JSON Lines 形式の削除ログ）

**3. unique index の追加** — 10本のマイグレーション（`up`/`down` 可逆）

## 実測（development DB）

| テーブル | 総数 | 余分（前→後） | unique index |
|---|---|---|---|
| apple_music_albums | 3,785→3,742 | 43 → **0** | `apple_music_id` |
| apple_music_tracks | 36,079→35,592 | 487 → **0** | `apple_music_album_id, apple_music_id` |
| spotify_tracks | 46,442→46,428 | 14 → **0** | `spotify_album_id, spotify_id` |
| spotify_track_audio_features | 45,728→45,644 | 70 → **0** | `spotify_track_id` |
| line_music_tracks | 35,264→35,257 | 7 → **0** | `line_music_album_id, line_music_id` |
| ytmusic_albums | 3,748→3,742 | 6 → **0** | `album_id, browse_id` |
| ytmusic_tracks | 35,676→35,619 | 10 → **0** | `ytmusic_album_id, track_id` |
| line_music_albums | 3,684 | 0 | `album_id, line_music_id` |

直接削除156件＋連鎖削除542件＝**698件**を除去。

## 残す行の基準（実測に基づく）

一律に「最古を残す」と**正しいデータを消す**ケースが2つあったため、テーブルごとに基準を変えています。

- **LineMusicTrack は最新を残す** — 2022年の7行は ISRC が1つズレており、Spotify との照合で **0/7 一致**。2026年の行が **7/7 一致**
- **YtmusicTrack は親アルバムの payload に載っている video_id を持つ行を残す** — 最古のみ該当が8件、最新のみ該当が2件で一律ルールでは選べない
- **AppleMusicAlbum / YtmusicAlbum は削除前に最新行の属性を keeper へマージ**（22件実施。古いアルバム名が残るのを防ぐ）
- それ以外は最古を残す（`SpotifyTrackAudioFeature` のみ再解析のため最新）

## 意図的に残した重複

同一の外部IDが**別JANのAlbum**に紐づくケース（LINE MUSIC 20件、YouTube Music 7件）は正当なデータのため削除せず、unique index を `(album_id, 外部ID)` の複合にすることで両立させています。

## 検証

- `make rubocop` 無指摘 / `make minitest` **194 runs, 1249 assertions, 0 failures** / `bin/rails zeitwerk:check` OK
- dedupe 再実行で **0件**（冪等）
- 孤児レコード全経路 **0件**、`Track`・`TracksOriginalSong`（原曲紐付け）への波及なし
- 配信リンクを失った Album **0件**、keeper のトラック数が `total_tracks` 未満のもの **0件**

## 既知の残課題（別Issue）

`ytmusic_tracks` に、多ディスクアルバムを `track_number` だけで突合しているためのディスク跨ぎ誤マッチが153行残っています（8アルバム）。加えて `ytmusic_albums` 3,742件のうち約1,990件で payload の `video_id` が null に劣化しており、突合ロジックの修正・payload取得の修復・再取得が必要です。
