### PR TITLE
YouTube Musicの縮退レスポンスによるpayload劣化を修復し再発を防止

### DIFF
--- a/app/models/admin/actions.rb
+++ b/app/models/admin/actions.rb
@@ -934,7 +934,13 @@ module Admin
             end
 
             url = "https://music.youtube.com/browse/#{ytmusic_album.browse_id}"
-            ytmusic_album.update_album(album, url)
+            unless ytmusic_album.update_album(album, url)
+              mutex.synchronize do
+                error_count += 1
+                errors << "#{ytmusic_album.name}: 縮退レスポンスのためスキップしました"
+              end
+              next
+            end
 
             mutex.synchronize { success_count += 1 }
             Rails.logger.info "ペイロード更新成功: #{album.title}"
@@ -1208,7 +1214,10 @@ module Admin
           end
 
           url = "https://music.youtube.com/browse/#{ytmusic_album.browse_id}"
-          ytmusic_album.update_album(album, url)
+          unless ytmusic_album.update_album(album, url)
+            error("アルバム「#{album.title}」: 縮退レスポンスのためスキップしました")
+            return
+          end
 
           Rails.logger.info "ペイロード更新成功: #{album.title}"
           succeed "アルバム「#{album.title}」のペイロードを更新しました"

--- a/app/models/ytmusic_album.rb
+++ b/app/models/ytmusic_album.rb
@@ -87,18 +87,16 @@ class YtmusicAlbum < ApplicationRecord
   }.freeze
 
   def self.save_album(album_id, browse_id, album)
+    if album.degraded?
+      Rails.logger.warn "browse_id: #{browse_id} の取得結果が縮退しているため保存をスキップしました"
+      return nil
+    end
+
     ytmusic_album = find_or_create_by!(album_id:, browse_id:) do |record|
       record.name = album.title
     end
 
-    ytmusic_album.update!(
-      name: album.title,
-      url: "https://music.youtube.com/browse/#{browse_id}",
-      playlist_url: album.playlist_url,
-      total_tracks: album.track_total_count,
-      release_year: album.year,
-      payload: album.as_json
-    )
+    ytmusic_album.update_album(album, "https://music.youtube.com/browse/#{browse_id}")
     ytmusic_album
   end
 
@@ -158,8 +156,7 @@ class YtmusicAlbum < ApplicationRecord
     ytmusic_album = YtMusic::Album.find(browse_id)
     return false if ytmusic_album.nil? || album.total_tracks != ytmusic_album.track_total_count
 
-    save_album(album.album_id, browse_id, ytmusic_album)
-    true
+    save_album(album.album_id, browse_id, ytmusic_album).present?
   end
   # rubocop:enable Naming/PredicateMethod
 
@@ -170,12 +167,22 @@ class YtmusicAlbum < ApplicationRecord
     ytmusic_album = YtMusic::Album.find(ytm_album.browse_id)
     return false if ytmusic_album.nil? || album.total_tracks != ytmusic_album.track_total_count
 
-    save_album(album.album_id, ytm_album.browse_id, ytmusic_album)
-    true
+    save_album(album.album_id, ytm_album.browse_id, ytmusic_album).present?
   end
   # rubocop:enable Naming/PredicateMethod
 
   def update_album(album, url)
+    if album.degraded?
+      Rails.logger.warn "YtmusicAlbum##{id} (browse_id: #{browse_id}) の取得結果が縮退しているためpayload更新をスキップしました"
+      return false
+    end
+
+    existing_count = existing_playable_track_count
+    if existing_count.positive? && album.playable_track_count < existing_count
+      Rails.logger.warn "YtmusicAlbum##{id} (browse_id: #{browse_id}) の取得結果は既存 #{existing_count} 件 → 取得 #{album.playable_track_count} 件 で悪化するためpayload更新をスキップしました"
+      return false
+    end
+
     update(
       name: album.title,
       release_year: album.year,
@@ -340,5 +347,16 @@ class YtmusicAlbum < ApplicationRecord
         end
       end
     end
+  end
+
+  private
+
+  # 既存payload中の「video_idが非nilかつtrack_numberが正の整数」であるトラック数。
+  # 既存payloadが無い/tracksが空の場合は0を返す（回帰ガードは0件からの改善を常に許可するため）。
+  def existing_playable_track_count
+    tracks = payload&.dig('tracks')
+    return 0 unless tracks.is_a?(Array)
+
+    tracks.count { |track| track['video_id'].present? && track['track_number'].to_i.positive? }
   end
 end

--- a/lib/repair/ytmusic_album_payloads.rb
+++ b/lib/repair/ytmusic_album_payloads.rb
@@ -8,6 +8,8 @@ module Repair
   # 実装済みのため、ここでは「対象の抽出」「リトライしての再取得」「進捗集計」だけを担当する。
   #
   # 実行は既定でdry-run。`apply: true` を指定したときだけ実際にAPIを呼び直しDBを更新する。
+  # `all: true` を指定すると劣化の有無を問わず全アルバムを再取得対象にする（パーサ改修の恩恵を
+  # 既存payloadへ反映させたいとき用。回帰ガードにより既存payloadが悪化することはない）。
   class YtmusicAlbumPayloads
     DEFAULT_MAX_ATTEMPTS = 3
     DEFAULT_BASE_INTERVAL = 1.0
@@ -38,9 +40,11 @@ module Repair
             )
     SQL
 
-    # dry-run時の内訳集計用。相互排他な4分類（合計は必ず対象件数と一致する）。
+    # dry-run時の内訳集計用。相互排他な5分類（合計は必ず対象件数と一致する）。
     # CASEの分岐順は上から順に「tracks欠損」→「全トラックnull」→「一部null」→
-    # 「video_idは揃っているがtrack_number欠落」の優先度で判定する。
+    # 「video_idは揃っているがtrack_number欠落」の優先度で判定し、どれにも当てはまらない行を
+    # 'healthy' とする。劣化のみモードでは対象が必ず DEGRADED_CONDITION_SQL を満たすため
+    # 'healthy' には決して分類されず、全件モードのときだけ健全な行がここに入る。
     BREAKDOWN_CASE_SQL = <<~SQL.squish
       CASE
         WHEN jsonb_typeof(payload->'tracks') IS DISTINCT FROM 'array' OR jsonb_array_length(payload->'tracks') = 0
@@ -51,7 +55,10 @@ module Repair
         WHEN EXISTS (
           SELECT 1 FROM jsonb_array_elements(payload->'tracks') tr WHERE tr->>'video_id' IS NULL
         ) THEN 'partial_null'
-        ELSE 'missing_track_number'
+        WHEN EXISTS (
+          SELECT 1 FROM jsonb_array_elements(payload->'tracks') tr WHERE #{TRACK_NUMBER_MISSING_SQL}
+        ) THEN 'missing_track_number'
+        ELSE 'healthy'
       END
     SQL
 
@@ -59,19 +66,21 @@ module Repair
       'all_null' => '全トラックnull',
       'partial_null' => '一部null',
       'missing_tracks' => 'tracks欠損',
-      'missing_track_number' => 'track_number欠落'
+      'missing_track_number' => 'track_number欠落',
+      'healthy' => '劣化なし'
     }.freeze
 
     # rubocop:disable Metrics/ParameterLists -- 呼び出し側（rakeタスク・テスト）が個別に指定できる必要がある設定値のため、
     # オプションハッシュへの集約はせずキーワード引数のまま公開する。
     def initialize(apply: false, limit: nil, workers: :ytmusic, max_attempts: DEFAULT_MAX_ATTEMPTS,
-                   base_interval: DEFAULT_BASE_INTERVAL, sync_tracks: false, out: $stdout)
+                   base_interval: DEFAULT_BASE_INTERVAL, sync_tracks: false, all: false, out: $stdout)
       @apply = apply
       @limit = limit
       @workers = workers
       @max_attempts = max_attempts
       @base_interval = base_interval
       @sync_tracks = sync_tracks
+      @all = all
       @out = out
     end
     # rubocop:enable Metrics/ParameterLists
@@ -91,13 +100,15 @@ module Repair
 
     def apply? = @apply
     def sync_tracks? = @sync_tracks
+    def all? = @all
 
     # ------------------------------------------------------------------
     # 対象抽出（読み取り専用）
     # ------------------------------------------------------------------
 
     def target_ids
-      scope = YtmusicAlbum.unscoped.where(DEGRADED_CONDITION_SQL).order(:id)
+      scope = YtmusicAlbum.unscoped.order(:id)
+      scope = scope.where(DEGRADED_CONDITION_SQL) unless all?
       scope = scope.limit(limit) if limit
       scope.pluck(:id)
     end
@@ -152,6 +163,8 @@ module Repair
       ytmusic_album = YtmusicAlbum.unscoped.find_by(id:)
       return :not_found if ytmusic_album.nil?
 
+      # YtMusic::Album.findは、レスポンスにerrorがある場合だけでなく、YouTube上でアルバムが
+      # 削除/視聴不可になりcontentsが欠落している場合もnilを返す。いずれも再試行では回復しない。
       album = fetch_album(ytmusic_album.browse_id)
       return :not_found if album.nil?
 
@@ -216,7 +229,7 @@ module Repair
 
     def build_result(target_count:, applied:, counters: Hash.new(0), elapsed: 0.0, skipped_browse_ids: [])
       {
-        target_count:, applied:, elapsed:,
+        target_count:, applied:, all: all?, elapsed:,
         repaired: counters[:repaired], still_degraded: counters[:still_degraded],
         not_found: counters[:not_found], error: counters[:error],
         skipped_browse_ids:
@@ -230,6 +243,7 @@ module Repair
     def print_header(target_count)
       out.puts '=' * 90
       out.puts "YouTube Music アルバムpayloadの縮退修復 (#{apply? ? 'APPLY: 実行します' : 'DRY-RUN: 実行しません'})"
+      out.puts "対象モード: #{all? ? '全件（劣化の有無を問わない）' : '劣化のみ'}"
       out.puts "対象件数: #{target_count} 件"
       out.puts "ワーカー: #{workers.inspect}（ParallelRunner.effective_workers で解決。PARALLEL_WORKERSで上書き可）"
       out.puts "リトライ設定: max_attempts=#{max_attempts} / base_interval=#{base_interval}秒（指数バックオフ + ジッタ±30%）"

--- a/lib/repair/ytmusic_album_payloads.rb
+++ b/lib/repair/ytmusic_album_payloads.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+module Repair
+  # YouTube Music側のレート制限等により保存されてしまった「縮退レスポンス」(tracksのvideo_idが
+  # 欠落した不完全なデータ) の ytmusic_albums.payload を、同じ browse_id を再取得して修復する。
+  #
+  # 縮退の判定・保存スキップは既に YtMusic::Album#degraded? / YtmusicAlbum#update_album に
+  # 実装済みのため、ここでは「対象の抽出」「リトライしての再取得」「進捗集計」だけを担当する。
+  #
+  # 実行は既定でdry-run。`apply: true` を指定したときだけ実際にAPIを呼び直しDBを更新する。
+  class YtmusicAlbumPayloads
+    DEFAULT_MAX_ATTEMPTS = 3
+    DEFAULT_BASE_INTERVAL = 1.0
+
+    # 一度のAPPLYで ParallelRunner.each に渡すスライスサイズ。
+    SLICE_SIZE = 1000
+
+    # バックオフ間隔に掛けるジッタの振れ幅（±30%）。
+    JITTER_RANGE = -30..30
+
+    # trackのtrack_numberが「欠落 / 空文字 / 0 / 数値として解釈できない値」であるかどうかの判定式。
+    # 数値形式(-?[0-9]+)であることを正規表現で確認してから::intへキャストすることで、
+    # 想定外の文字列が入っていてもキャスト例外を起こさず「track_number欠落」として扱う。
+    TRACK_NUMBER_MISSING_SQL = <<~SQL.squish
+      CASE WHEN (tr->>'track_number') ~ '^-?[0-9]+$' THEN (tr->>'track_number')::int ELSE 0 END = 0
+    SQL
+
+    # 対象抽出条件: tracksが配列でない/空、またはいずれかのtrackのvideo_idがnull、
+    # またはいずれかのtrackのtrack_numberが欠落/0（古い縮退保存の残骸でtrack_numberだけが
+    # 0のまま残っているケースを拾うため）の行。
+    DEGRADED_CONDITION_SQL = <<~SQL.squish
+      jsonb_typeof(payload->'tracks') IS DISTINCT FROM 'array'
+         OR jsonb_array_length(payload->'tracks') = 0
+         OR EXISTS (
+              SELECT 1 FROM jsonb_array_elements(payload->'tracks') tr
+              WHERE tr->>'video_id' IS NULL
+                 OR #{TRACK_NUMBER_MISSING_SQL}
+            )
+    SQL
+
+    # dry-run時の内訳集計用。相互排他な4分類（合計は必ず対象件数と一致する）。
+    # CASEの分岐順は上から順に「tracks欠損」→「全トラックnull」→「一部null」→
+    # 「video_idは揃っているがtrack_number欠落」の優先度で判定する。
+    BREAKDOWN_CASE_SQL = <<~SQL.squish
+      CASE
+        WHEN jsonb_typeof(payload->'tracks') IS DISTINCT FROM 'array' OR jsonb_array_length(payload->'tracks') = 0
+          THEN 'missing_tracks'
+        WHEN NOT EXISTS (
+          SELECT 1 FROM jsonb_array_elements(payload->'tracks') tr WHERE tr->>'video_id' IS NOT NULL
+        ) THEN 'all_null'
+        WHEN EXISTS (
+          SELECT 1 FROM jsonb_array_elements(payload->'tracks') tr WHERE tr->>'video_id' IS NULL
+        ) THEN 'partial_null'
+        ELSE 'missing_track_number'
+      END
+    SQL
+
+    BREAKDOWN_LABELS = {
+      'all_null' => '全トラックnull',
+      'partial_null' => '一部null',
+      'missing_tracks' => 'tracks欠損',
+      'missing_track_number' => 'track_number欠落'
+    }.freeze
+
+    # rubocop:disable Metrics/ParameterLists -- 呼び出し側（rakeタスク・テスト）が個別に指定できる必要がある設定値のため、
+    # オプションハッシュへの集約はせずキーワード引数のまま公開する。
+    def initialize(apply: false, limit: nil, workers: :ytmusic, max_attempts: DEFAULT_MAX_ATTEMPTS,
+                   base_interval: DEFAULT_BASE_INTERVAL, sync_tracks: false, out: $stdout)
+      @apply = apply
+      @limit = limit
+      @workers = workers
+      @max_attempts = max_attempts
+      @base_interval = base_interval
+      @sync_tracks = sync_tracks
+      @out = out
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    def run
+      ids = target_ids
+      print_header(ids.size)
+
+      return finish_dry_run(ids) unless apply?
+
+      finish_apply(ids)
+    end
+
+    private
+
+    attr_reader :limit, :workers, :max_attempts, :base_interval, :out
+
+    def apply? = @apply
+    def sync_tracks? = @sync_tracks
+
+    # ------------------------------------------------------------------
+    # 対象抽出（読み取り専用）
+    # ------------------------------------------------------------------
+
+    def target_ids
+      scope = YtmusicAlbum.unscoped.where(DEGRADED_CONDITION_SQL).order(:id)
+      scope = scope.limit(limit) if limit
+      scope.pluck(:id)
+    end
+
+    # 「全トラックnull / 一部null / tracks欠損 / track_number欠落」の内訳を
+    # 1本のSQL(CASE + GROUP BY)で集計する。
+    def breakdown(ids)
+      YtmusicAlbum.unscoped.where(id: ids).group(Arel.sql(BREAKDOWN_CASE_SQL)).count
+    end
+
+    # ------------------------------------------------------------------
+    # dry-run
+    # ------------------------------------------------------------------
+
+    def finish_dry_run(ids)
+      print_breakdown(breakdown(ids)) if ids.any?
+      out.puts 'dry-run のため修復していません。実行するには APPLY=1 を付けて再実行してください。'
+      build_result(target_count: ids.size, applied: false)
+    end
+
+    # ------------------------------------------------------------------
+    # apply（1スライスごとに ParallelRunner.each で並列処理）
+    # ------------------------------------------------------------------
+
+    def finish_apply(ids)
+      counters = Hash.new(0)
+      skipped_browse_ids = []
+      browse_id_by_id = YtmusicAlbum.unscoped.where(id: ids).pluck(:id, :browse_id).to_h
+      processed = 0
+      started_at = monotonic_now
+
+      ids.each_slice(SLICE_SIZE) do |slice|
+        finish_callback = lambda do |id, _index, outcome|
+          counters[outcome] += 1
+          skipped_browse_ids << browse_id_by_id[id] if outcome == :still_degraded && skipped_browse_ids.size < 10
+          processed += 1
+          print_progress(processed, ids.size, counters)
+        end
+
+        ParallelRunner.each(slice, workers:, finish: finish_callback) { |id| repair_album(id) }
+      end
+
+      elapsed = monotonic_now - started_at
+      print_summary(ids.size, counters, elapsed, skipped_browse_ids)
+
+      build_result(target_count: ids.size, applied: true, counters:, elapsed:, skipped_browse_ids:)
+    end
+
+    # 子プロセス（forkモード時）またはテスト時は逐次実行の中で呼ばれる。
+    # 例外はここで必ず握って :error を返し、他レコードの処理を止めない。
+    def repair_album(id)
+      ytmusic_album = YtmusicAlbum.unscoped.find_by(id:)
+      return :not_found if ytmusic_album.nil?
+
+      album = fetch_album(ytmusic_album.browse_id)
+      return :not_found if album.nil?
+
+      url = "https://music.youtube.com/browse/#{ytmusic_album.browse_id}"
+      return :still_degraded unless ytmusic_album.update_album(album, url)
+
+      sync_tracks(ytmusic_album) if sync_tracks?
+      :repaired
+    rescue StandardError => e
+      Rails.logger.error "Repair::YtmusicAlbumPayloads: id=#{id} browse_id=#{ytmusic_album&.browse_id.inspect} #{e.class}: #{e.message}"
+      :error
+    end
+
+    # 縮退している間は指数バックオフ + ジッタを挟みながら max_attempts 回まで再取得する。
+    # 最後まで縮退していた場合は、そのdegradedなalbumをそのまま返す（呼び出し元でstill_degraded判定）。
+    def fetch_album(browse_id)
+      attempt = 1
+      loop do
+        album = YtMusic::Album.find(browse_id)
+        return album if album.nil? || !album.degraded?
+        return album if attempt >= max_attempts
+
+        sleep(backoff_interval(attempt))
+        attempt += 1
+      end
+    end
+
+    def backoff_interval(attempt)
+      base_interval * (2**(attempt - 1)) * jitter_factor
+    end
+
+    def jitter_factor
+      1 + (rand(JITTER_RANGE) / 100.0)
+    end
+
+    # 修復済みのpayloadを元に、track_numberで突き合わせて YtmusicTrack も同期する。
+    # album.as_json を呼び直さず、update_album が既に保存した payload をそのまま使う。
+    def sync_tracks(ytmusic_album)
+      tracks_by_number = payload_tracks_by_number(ytmusic_album.payload['tracks'])
+      return if tracks_by_number.empty?
+
+      YtmusicTrack.unscoped.where(ytmusic_album_id: ytmusic_album.id).find_each do |ytmusic_track|
+        next if ytmusic_track.track_number.to_i.zero?
+
+        payload_track = tracks_by_number[ytmusic_track.track_number]
+        ytmusic_track.update_track(payload_track) if payload_track
+      end
+    end
+
+    def payload_tracks_by_number(tracks)
+      Array(tracks).each_with_object({}) do |track, index|
+        track_number = track['track_number']
+        next if track_number.to_i.zero?
+
+        index[track_number] = track
+      end
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def build_result(target_count:, applied:, counters: Hash.new(0), elapsed: 0.0, skipped_browse_ids: [])
+      {
+        target_count:, applied:, elapsed:,
+        repaired: counters[:repaired], still_degraded: counters[:still_degraded],
+        not_found: counters[:not_found], error: counters[:error],
+        skipped_browse_ids:
+      }
+    end
+
+    # ------------------------------------------------------------------
+    # 出力
+    # ------------------------------------------------------------------
+
+    def print_header(target_count)
+      out.puts '=' * 90
+      out.puts "YouTube Music アルバムpayloadの縮退修復 (#{apply? ? 'APPLY: 実行します' : 'DRY-RUN: 実行しません'})"
+      out.puts "対象件数: #{target_count} 件"
+      out.puts "ワーカー: #{workers.inspect}（ParallelRunner.effective_workers で解決。PARALLEL_WORKERSで上書き可）"
+      out.puts "リトライ設定: max_attempts=#{max_attempts} / base_interval=#{base_interval}秒（指数バックオフ + ジッタ±30%）"
+      out.puts "sync_tracks: #{sync_tracks? ? '有効' : '無効'}"
+      out.puts '=' * 90
+    end
+
+    def print_breakdown(counts)
+      out.puts '内訳（相互排他な分類。合計は対象件数と一致します）:'
+      BREAKDOWN_LABELS.each do |key, label|
+        out.puts "  #{label}: #{counts.fetch(key, 0)} 件"
+      end
+    end
+
+    def print_progress(processed, total, counters)
+      out.puts "処理中: #{processed}/#{total} " \
+               "(修復:#{counters[:repaired]} 縮退:#{counters[:still_degraded]} " \
+               "未検出:#{counters[:not_found]} エラー:#{counters[:error]})"
+    end
+
+    def print_summary(total, counters, elapsed, skipped_browse_ids)
+      out.puts '-' * 90
+      out.puts "完了: 対象 #{total} 件 / 修復 #{counters[:repaired]} 件 / " \
+               "縮退のままスキップ #{counters[:still_degraded]} 件 / " \
+               "取得失敗(未検出) #{counters[:not_found]} 件 / エラー #{counters[:error]} 件"
+      out.puts format('経過時間: %<elapsed>.1f 秒', elapsed:)
+      out.puts "今回スキップしたbrowse_id (最大10件): #{skipped_browse_ids.join(', ')}" if skipped_browse_ids.present?
+    end
+  end
+end

--- a/lib/tasks/ytmusic.rake
+++ b/lib/tasks/ytmusic.rake
@@ -118,13 +118,14 @@ namespace :ytmusic do
     end
   end
 
-  desc 'YouTube Music アルバムの劣化した payload を再取得して修復する（既定はdry-run。APPLY=1で実行。PARALLEL_WORKERSでワーカー数を上書き可能）'
+  desc 'YouTube Music アルバムの劣化した payload を再取得して修復する（既定はdry-run。APPLY=1で実行。PARALLEL_WORKERSでワーカー数を上書き可能。ALL=1で劣化の有無に関わらず全アルバムを再取得。回帰ガードにより既存payloadが悪化することはない）'
   task repair_degraded_album_payloads: :environment do
     Repair::YtmusicAlbumPayloads.new(
       apply: ENV['APPLY'] == '1',
       limit: ENV['LIMIT'].presence&.to_i,
       max_attempts: ENV.fetch('MAX_ATTEMPTS', Repair::YtmusicAlbumPayloads::DEFAULT_MAX_ATTEMPTS).to_i,
-      sync_tracks: ENV['SYNC_TRACKS'] == '1'
+      sync_tracks: ENV['SYNC_TRACKS'] == '1',
+      all: ENV['ALL'] == '1'
     ).run
   end
 end

--- a/lib/tasks/ytmusic.rake
+++ b/lib/tasks/ytmusic.rake
@@ -92,7 +92,7 @@ namespace :ytmusic do
       count += 1
       print "\rアルバム: #{count}/#{max_count} Progress: #{(count * 100.0 / max_count).round(1)}%"
 
-      album = YTMusic::Album.find(ytmusic_album.browse_id)
+      album = YtMusic::Album.find(ytmusic_album.browse_id)
       url = "https://music.youtube.com/browse/#{ytmusic_album.browse_id}"
       ytmusic_album.update_album(album, url) if album
     end
@@ -106,7 +106,7 @@ namespace :ytmusic do
       count += 1
       print "\rアルバム: #{count}/#{max_count} Progress: #{(count * 100.0 / max_count).round(1)}%"
 
-      album = YTMusic::Album.find(ytmusic_album.browse_id)
+      album = YtMusic::Album.find(ytmusic_album.browse_id)
       url = "https://music.youtube.com/browse/#{ytmusic_album.browse_id}"
       ytmusic_album.update_album(album, url) if album
 
@@ -116,5 +116,15 @@ namespace :ytmusic do
         ytm_track.update_track(track) if track
       end
     end
+  end
+
+  desc 'YouTube Music アルバムの劣化した payload を再取得して修復する（既定はdry-run。APPLY=1で実行。PARALLEL_WORKERSでワーカー数を上書き可能）'
+  task repair_degraded_album_payloads: :environment do
+    Repair::YtmusicAlbumPayloads.new(
+      apply: ENV['APPLY'] == '1',
+      limit: ENV['LIMIT'].presence&.to_i,
+      max_attempts: ENV.fetch('MAX_ATTEMPTS', Repair::YtmusicAlbumPayloads::DEFAULT_MAX_ATTEMPTS).to_i,
+      sync_tracks: ENV['SYNC_TRACKS'] == '1'
+    ).run
   end
 end

--- a/lib/yt_music/album.rb
+++ b/lib/yt_music/album.rb
@@ -27,9 +27,9 @@ module YtMusic
       @year = extract_year_from_subtitle(subtitle)
       strapline_text_one = header.dig('straplineTextOne', 'runs')
       artist_contents = strapline_text_one&.filter { it['text'] != ' • ' }&.filter { it['text'] != '、' }
-      return if artist_contents.blank?
-
-      @artists = artist_contents.map { Artist.new it }
+      # straplineTextOneが欠落した縮退レスポンスでも空配列を設定し、以降の項目を組み立てる
+      # （縮退の検出はdegraded?に任せる）。
+      @artists = artist_contents.present? ? artist_contents.map { Artist.new it } : []
 
       @track_total_count = header.dig('secondSubtitle', 'runs', 0, 'text').to_i
       @duration_text = header.dig('secondSubtitle', 'runs', 2, 'text')
@@ -37,9 +37,21 @@ module YtMusic
       @thumbnails = thumbnails.map { Thumbnail.new it }
       @playlist_url = response.dig('microformat', 'microformatDataRenderer', 'urlCanonical')
       track_contents = response.dig('contents', 'twoColumnBrowseResultsRenderer', 'secondaryContents', 'sectionListRenderer', 'contents', 0, 'musicShelfRenderer', 'contents')
-      @tracks = track_contents.map { Track.new it }
+      @tracks = track_contents.map { Track.new it, album_artists: @artists }
       @duration_seconds = @tracks.sum(&:duration_seconds)
       super()
+    end
+
+    # YouTube側の縮退レスポンス（全トラックのvideo_id/track_numberが欠落した完全な取得失敗）を検知する。
+    # 一部のトラックだけplaylist_idが欠けている等、再生に支障のない部分的な欠落は縮退とみなさない
+    # （回帰ガードはYtmusicAlbum#update_album側で別途行う）。
+    def degraded?
+      tracks.blank? || tracks.none?(&:playable?)
+    end
+
+    # 再生可能（video_idとtrack_numberが揃っている）なトラックの件数。
+    def playable_track_count
+      Array(tracks).count(&:playable?)
     end
 
     private

--- a/lib/yt_music/album.rb
+++ b/lib/yt_music/album.rb
@@ -7,11 +7,22 @@ module YtMusic
         response = super(id, 'album')
         return nil if response['error'].present?
 
+        if extract_header(response).nil?
+          Rails.logger.warn "YtMusic::Album.find: browse_id=#{id} のアルバムのコンテンツが取得できませんでした (削除/視聴不可の可能性があります)"
+          return nil
+        end
+
         Album.new response
       end
 
       def search(query)
         super(query, 'albums')
+      end
+
+      # レスポンスからアルバムのヘッダー情報（タイトル・サブタイトル等）を取り出す。
+      # 削除/視聴不可のアルバムでは `contents` 自体が存在せず、この戻り値がnilになる。
+      def extract_header(response)
+        response.dig('contents', 'twoColumnBrowseResultsRenderer', 'tabs', 0, 'tabRenderer', 'content', 'sectionListRenderer', 'contents', 0, 'musicResponsiveHeaderRenderer')
       end
     end
 
@@ -20,7 +31,9 @@ module YtMusic
                 :tracks, :duration_seconds
 
     def initialize(response)
-      header = response.dig('contents', 'twoColumnBrowseResultsRenderer', 'tabs', 0, 'tabRenderer', 'content', 'sectionListRenderer', 'contents', 0, 'musicResponsiveHeaderRenderer')
+      header = self.class.extract_header(response)
+      raise ArgumentError, 'アルバムのコンテンツが取得できませんでした（削除/視聴不可の可能性があります）' if header.nil?
+
       @title = header.dig('title', 'runs', 0, 'text')
       subtitle = header.dig('subtitle', 'runs')
       @type = subtitle&.shift&.dig('text')

--- a/lib/yt_music/response.rb
+++ b/lib/yt_music/response.rb
@@ -13,10 +13,12 @@ module YtMusic
     def parser(response)
       result = {}
       contents = response.dig('contents', 'tabbedSearchResultsRenderer', 'tabs', 0, 'tabRenderer', 'content', 'sectionListRenderer', 'contents')
-      contents.each do |content|
-        next if content['itemSectionRenderer']
+      return result if contents.blank?
 
+      contents.each do |content|
         ctx = content['musicShelfRenderer']
+        next if ctx.blank?
+
         category = ctx.dig('title', 'runs', 0, 'text')
         case category
         when 'アルバム'

--- a/lib/yt_music/track.rb
+++ b/lib/yt_music/track.rb
@@ -2,28 +2,85 @@
 
 module YtMusic
   class Track < Base
-    attr_reader :title, :video_id, :playlist_id, :url, :track_number, :artists, :duration, :duration_seconds
+    # YouTube側の概数表記（例: "1.2万"）を数値化する際の桁の乗数。
+    VIEW_COUNT_UNIT_MULTIPLIERS = { '千' => 1_000, '万' => 10_000, '億' => 100_000_000 }.freeze
 
-    def initialize(content)
+    attr_reader :title, :video_id, :playlist_id, :url, :track_number, :artists, :duration, :duration_seconds,
+                :view_count_text, :view_count
+
+    def initialize(content, album_artists: nil)
       item = content['musicResponsiveListItemRenderer']
-      flex_columns = item.dig('flexColumns', 0, 'musicResponsiveListItemFlexColumnRenderer', 'text', 'runs', 0)
-      @title = flex_columns['text']
-      @video_id = flex_columns.dig('navigationEndpoint', 'watchEndpoint', 'videoId')
-      @playlist_id = flex_columns.dig('navigationEndpoint', 'watchEndpoint', 'playlistId')
+      flex_column = item.dig('flexColumns', 0, 'musicResponsiveListItemFlexColumnRenderer', 'text', 'runs', 0)
+      @title = flex_column['text']
+      @video_id = extract_video_id(item, flex_column)
+      @playlist_id = extract_playlist_id(item, flex_column)
       @url = "https://music.youtube.com/watch?v=#{@video_id}&list=#{@playlist_id}" if @video_id && @playlist_id
-      @track_number = item.dig('index', 'runs', 0, 'text').to_i
-
-      # track_numberが0の場合はエラーを発生させる
-      raise ArgumentError, "Invalid track number: 0 (title: #{@title})" if @track_number.zero?
-
-      artist_contents = item.dig('flexColumns', 1, 'musicResponsiveListItemFlexColumnRenderer', 'text', 'runs')&.filter { it['text'] != '、' }
-      @artists = artist_contents.map { Artist.new it } if artist_contents.present?
+      @track_number = extract_track_number(item)
+      @artists = extract_artists(item, album_artists)
       @duration = item.dig('fixedColumns', 0, 'musicResponsiveListItemFixedColumnRenderer', 'text', 'runs', 0, 'text')
       if @duration
         mapped_increments = [1, 60, 3600].zip(@duration.split(':').reverse)
         @duration_seconds = mapped_increments.sum { |multiplier, time| multiplier * time.to_i }
       end
+      @view_count_text = extract_view_count_text(item)
+      @view_count = extract_view_count(@view_count_text)
       super()
+    end
+
+    def complete?
+      video_id.present? && playlist_id.present? && track_number.to_i.positive?
+    end
+
+    def playable?
+      video_id.present? && track_number.to_i.positive?
+    end
+
+    private
+
+    # トラック別のアーティスト列（flexColumns[1]）が無い/空の場合は、呼び出し元から渡された
+    # アルバムのアーティストにフォールバックする（単一アーティストのアルバムでは列自体が無いことが多い）。
+    def extract_artists(item, album_artists)
+      artist_contents = item.dig('flexColumns', 1, 'musicResponsiveListItemFlexColumnRenderer', 'text', 'runs')&.filter { it['text'] != '、' }
+      return artist_contents.map { Artist.new it } if artist_contents.present?
+
+      album_artists
+    end
+
+    def extract_view_count_text(item)
+      item.dig('flexColumns', 2, 'musicResponsiveListItemFlexColumnRenderer', 'text', 'runs', 0, 'text')
+    end
+
+    # flexColumns[2]は再生回数以外（アーティスト名等）のこともあるため、数字を含まない文字列は
+    # nilとして扱う。概数表記（千/万/億）のため、ここで得られる数値は近似値であり厳密値ではない。
+    def extract_view_count(text)
+      return nil if text.blank?
+
+      normalized = text.tr('０-９', '0-9').tr('．', '.').delete(',')
+      match = normalized.match(/(\d+(?:\.\d+)?)(#{VIEW_COUNT_UNIT_MULTIPLIERS.keys.join('|')})?/)
+      return nil unless match
+
+      multiplier = VIEW_COUNT_UNIT_MULTIPLIERS.fetch(match[2], 1)
+      (match[1].to_f * multiplier).round
+    end
+
+    # YouTube側がスロットリング時に navigationEndpoint を欠いた縮退レスポンスを返すことがあるため、
+    # videoIdは複数箇所からフォールバックして取得する。
+    def extract_video_id(item, flex_column)
+      flex_column.dig('navigationEndpoint', 'watchEndpoint', 'videoId').presence ||
+        item.dig('playlistItemData', 'videoId').presence ||
+        item.dig('overlay', 'musicItemThumbnailOverlayRenderer', 'content', 'musicPlayButtonRenderer',
+                 'playNavigationEndpoint', 'watchEndpoint', 'videoId').presence
+    end
+
+    def extract_playlist_id(item, flex_column)
+      flex_column.dig('navigationEndpoint', 'watchEndpoint', 'playlistId').presence ||
+        item.dig('overlay', 'musicItemThumbnailOverlayRenderer', 'content', 'musicPlayButtonRenderer',
+                 'playNavigationEndpoint', 'watchEndpoint', 'playlistId').presence
+    end
+
+    # 番号を捏造しないため、取得できない場合はnilを返す（0や配列位置からの推測はしない）。
+    def extract_track_number(item)
+      item.dig('index', 'runs', 0, 'text').presence&.to_i
     end
   end
 end

--- a/test/lib/repair/ytmusic_album_payloads_test.rb
+++ b/test/lib/repair/ytmusic_album_payloads_test.rb
@@ -64,6 +64,32 @@ module Repair
       assert_equal 0, result[:target_count]
     end
 
+    test '対象抽出: all: trueのとき劣化していないアルバムも対象になる' do
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1)]))
+      create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+
+      result = run_repair(apply: false, all: true)
+
+      assert_equal 2, result[:target_count]
+    end
+
+    test '対象抽出: all: false（既定）のとき劣化していないアルバムは対象にならない' do
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1)]))
+      create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+
+      result = run_repair(apply: false)
+
+      assert_equal 1, result[:target_count]
+    end
+
+    test '対象抽出: all: true かつ limitを指定すると件数が制限される' do
+      3.times { create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1)])) }
+
+      result = run_repair(apply: false, all: true, limit: 2)
+
+      assert_equal 2, result[:target_count]
+    end
+
     test 'dry-runの内訳にtrack_number欠落の件数が表示される' do
       create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1), track_with_zero_track_number]))
       out = StringIO.new
@@ -71,6 +97,16 @@ module Repair
       Repair::YtmusicAlbumPayloads.new(apply: false, out:).run
 
       assert_match(/track_number欠落: 1 件/, out.string)
+    end
+
+    test 'dry-run(all: true)の内訳に劣化なしの件数が表示される' do
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1)]))
+      create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+      out = StringIO.new
+
+      Repair::YtmusicAlbumPayloads.new(apply: false, all: true, out:).run
+
+      assert_match(/劣化なし: 1 件/, out.string)
     end
 
     test 'dry-runではpayloadを一切変更せずYtMusic::Album.findも呼ばない' do
@@ -135,6 +171,21 @@ module Repair
       result = nil
       stub_const(YtMusic, :Album, stub_find_client { |_browse_id| regressed_album }) do
         result = run_repair(apply: true, base_interval: 0)
+      end
+
+      assert_equal 1, result[:still_degraded]
+      assert_equal 0, result[:repaired]
+      assert_equal original_payload, ytmusic_album.reload.payload
+    end
+
+    test 'all: trueでも回帰ガードにより拒否されたアルバムはstill_degradedに計上される' do
+      original_payload = payload_with_two_playable_and_one_null_track
+      ytmusic_album = create_ytmusic_album(payload: original_payload)
+      regressed_album = build_regressed_album
+
+      result = nil
+      stub_const(YtMusic, :Album, stub_find_client { |_browse_id| regressed_album }) do
+        result = run_repair(apply: true, all: true, base_interval: 0)
       end
 
       assert_equal 1, result[:still_degraded]

--- a/test/lib/repair/ytmusic_album_payloads_test.rb
+++ b/test/lib/repair/ytmusic_album_payloads_test.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Repair
+  class YtmusicAlbumPayloadsTest < ActiveSupport::TestCase
+    FakeAlbum = Struct.new(:title, :year, :playlist_url, :track_total_count, :tracks_payload, :degraded,
+                           keyword_init: true) do
+      def as_json(*)
+        {
+          'title' => title, 'year' => year, 'playlist_url' => playlist_url,
+          'track_total_count' => track_total_count, 'tracks' => tracks_payload
+        }
+      end
+
+      def degraded?
+        degraded
+      end
+
+      def playable_track_count
+        Array(tracks_payload).count { |t| t['video_id'].present? && t['track_number'].to_i.positive? }
+      end
+    end
+
+    DEFAULT_FIXED_ALBUM_ATTRS = {
+      title: 'Fixed Title', year: '2024', playlist_url: 'https://music.youtube.com/playlist?list=PL1',
+      track_total_count: 1,
+      tracks_payload: [{ 'track_number' => 1, 'video_id' => 'v1', 'playlist_id' => 'pl1', 'title' => 'Track 1' }],
+      degraded: false
+    }.freeze
+
+    test '対象抽出: 全トラックnull・一部null・tracks欠損の劣化アルバムのみ選ばれ正常アルバムは選ばれない' do
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1)]))
+      create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1), degraded_track(track_number: 2)]))
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1), degraded_track(track_number: 2)]))
+      create_ytmusic_album(payload: {})
+
+      result = run_repair(apply: false)
+
+      assert_equal 3, result[:target_count]
+    end
+
+    test '対象抽出: video_idは揃っているがtrack_numberが0のトラックを含むアルバムも対象になる' do
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1), track_with_zero_track_number]))
+
+      result = run_repair(apply: false)
+
+      assert_equal 1, result[:target_count]
+    end
+
+    test '対象抽出: track_numberがnullのトラックを含むアルバムも対象になる' do
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1), track_with_null_track_number]))
+
+      result = run_repair(apply: false)
+
+      assert_equal 1, result[:target_count]
+    end
+
+    test '対象抽出: video_idもtrack_numberも揃っている正常アルバムは対象にならない' do
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1), complete_track(track_number: 2)]))
+
+      result = run_repair(apply: false)
+
+      assert_equal 0, result[:target_count]
+    end
+
+    test 'dry-runの内訳にtrack_number欠落の件数が表示される' do
+      create_ytmusic_album(payload: payload_with_tracks([complete_track(track_number: 1), track_with_zero_track_number]))
+      out = StringIO.new
+
+      Repair::YtmusicAlbumPayloads.new(apply: false, out:).run
+
+      assert_match(/track_number欠落: 1 件/, out.string)
+    end
+
+    test 'dry-runではpayloadを一切変更せずYtMusic::Album.findも呼ばない' do
+      untouched = create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+      original_payload = untouched.payload
+
+      result = nil
+      stub_const(YtMusic, :Album, raising_ytmusic_client) do
+        result = run_repair(apply: false)
+      end
+
+      assert_not result[:applied]
+      assert_equal 1, result[:target_count]
+      assert_equal 0, result[:repaired]
+      assert_equal original_payload, untouched.reload.payload
+    end
+
+    test 'apply正常系: 正常なalbumが返れば修復されpayloadが更新される' do
+      ytmusic_album = create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+      fixed_album = build_fixed_album
+
+      result = nil
+      stub_const(YtMusic, :Album, stub_find_client { |_browse_id| fixed_album }) do
+        result = run_repair(apply: true, base_interval: 0)
+      end
+
+      assert result[:applied]
+      assert_equal 1, result[:repaired]
+      assert_equal 0, result[:still_degraded]
+      ytmusic_album.reload
+
+      assert_equal 'Fixed Title', ytmusic_album.name
+      assert_equal fixed_album.as_json, ytmusic_album.payload
+    end
+
+    test 'apply縮退系: max_attempts回試行しても縮退のままならpayloadを変更せずstill_degradedになる' do
+      original_payload = payload_with_tracks([degraded_track(track_number: 1)])
+      ytmusic_album = create_ytmusic_album(payload: original_payload)
+      always_degraded_album = build_fixed_album(degraded: true)
+      call_count = 0
+
+      result = nil
+      fake_client = stub_find_client do |_browse_id|
+        call_count += 1
+        always_degraded_album
+      end
+      stub_const(YtMusic, :Album, fake_client) do
+        result = run_repair(apply: true, max_attempts: 3, base_interval: 0)
+      end
+
+      assert_equal 3, call_count
+      assert_equal 1, result[:still_degraded]
+      assert_equal 0, result[:repaired]
+      assert_equal original_payload, ytmusic_album.reload.payload
+    end
+
+    test '回帰ガードで拒否された場合もstill_degradedに計上されpayloadは変更されない' do
+      original_payload = payload_with_two_playable_and_one_null_track
+      ytmusic_album = create_ytmusic_album(payload: original_payload)
+      regressed_album = build_regressed_album
+
+      result = nil
+      stub_const(YtMusic, :Album, stub_find_client { |_browse_id| regressed_album }) do
+        result = run_repair(apply: true, base_interval: 0)
+      end
+
+      assert_equal 1, result[:still_degraded]
+      assert_equal 0, result[:repaired]
+      assert_equal original_payload, ytmusic_album.reload.payload
+    end
+
+    test 'スキップしたbrowse_idがサマリの結果に含まれる' do
+      ytmusic_album = create_ytmusic_album(payload: payload_with_two_playable_and_one_null_track)
+      regressed_album = build_regressed_album
+
+      result = nil
+      stub_const(YtMusic, :Album, stub_find_client { |_browse_id| regressed_album }) do
+        result = run_repair(apply: true, base_interval: 0)
+      end
+
+      assert_includes result[:skipped_browse_ids], ytmusic_album.browse_id
+    end
+
+    test 'YtMusic::Album.findがnilを返す場合はnot_foundに計上される' do
+      create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+
+      result = nil
+      stub_const(YtMusic, :Album, stub_find_client { |_browse_id| nil }) do
+        result = run_repair(apply: true, base_interval: 0)
+      end
+
+      assert_equal 1, result[:not_found]
+      assert_equal 0, result[:repaired]
+    end
+
+    test '例外が発生しても他のレコードの処理は継続しerrorに計上される' do
+      failing = create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+      succeeding = create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+      fixed_album = build_fixed_album
+
+      result = nil
+      fake_client = stub_find_client do |browse_id|
+        raise 'boom' if browse_id == failing.browse_id
+
+        fixed_album
+      end
+      stub_const(YtMusic, :Album, fake_client) do
+        result = run_repair(apply: true, base_interval: 0)
+      end
+
+      assert_equal 1, result[:error]
+      assert_equal 1, result[:repaired]
+      assert_equal 'Fixed Title', succeeding.reload.name
+    end
+
+    test '冪等性: 修復後に再実行すると対象0件になる' do
+      create_ytmusic_album(payload: payload_with_tracks([degraded_track(track_number: 1)]))
+      fixed_album = build_fixed_album
+
+      stub_const(YtMusic, :Album, stub_find_client { |_browse_id| fixed_album }) do
+        first_result = run_repair(apply: true, base_interval: 0)
+        second_result = run_repair(apply: false)
+
+        assert_equal 1, first_result[:repaired]
+        assert_equal 0, second_result[:target_count]
+      end
+    end
+
+    test 'sync_tracks: 修復後にtrack_numberで突き合わせてYtmusicTrackが同期される' do
+      album = create_album
+      track1 = create_track(album)
+      track2 = create_track(album)
+      track_zero = create_track(album)
+      ytmusic_album = create_ytmusic_album(
+        album:,
+        payload: payload_with_tracks([degraded_track(track_number: 1), degraded_track(track_number: 2)])
+      )
+      ytmusic_track1 = create_ytmusic_track(ytmusic_album:, album:, track: track1, track_number: 1, name: 'Old 1')
+      ytmusic_track2 = create_ytmusic_track(ytmusic_album:, album:, track: track2, track_number: 2, name: 'Old 2')
+      ytmusic_track_zero = create_ytmusic_track(ytmusic_album:, album:, track: track_zero, track_number: 0, name: 'Old 0')
+      fixed_album = build_fixed_album(tracks_payload: [
+                                        { 'track_number' => 1, 'video_id' => 'new1', 'playlist_id' => 'newpl1', 'title' => 'New Title 1' },
+                                        { 'track_number' => 2, 'video_id' => 'new2', 'playlist_id' => 'newpl2', 'title' => 'New Title 2' }
+                                      ])
+
+      stub_const(YtMusic, :Album, stub_find_client { |_browse_id| fixed_album }) do
+        run_repair(apply: true, base_interval: 0, sync_tracks: true)
+      end
+
+      assert_equal 'New Title 1', ytmusic_track1.reload.name
+      assert_equal 'new1', ytmusic_track1.payload['video_id']
+      assert_equal 'New Title 2', ytmusic_track2.reload.name
+      assert_equal 'new2', ytmusic_track2.payload['video_id']
+      assert_equal 'Old 0', ytmusic_track_zero.reload.name
+    end
+
+    private
+
+    # limit / workers / max_attempts / base_interval / sync_tracks はRepair::YtmusicAlbumPayloadsの
+    # デフォルト値をそのまま使う。個別のテストで変えたい値だけを渡す。
+    def run_repair(apply:, **)
+      Repair::YtmusicAlbumPayloads.new(apply:, out: StringIO.new, **).run
+    end
+
+    # `YtMusic::Album.find` が一度でも呼ばれたら失敗させ、dry-run時にAPI呼び出しがないことを検証するためのfake。
+    def raising_ytmusic_client
+      stub_find_client { |_browse_id| raise 'YtMusic::Album.find should not be called during dry-run' }
+    end
+
+    def stub_find_client(&)
+      Class.new do
+        define_singleton_method(:find, &)
+      end
+    end
+
+    def build_fixed_album(**overrides)
+      FakeAlbum.new(**DEFAULT_FIXED_ALBUM_ATTRS, **overrides)
+    end
+
+    def payload_with_tracks(tracks)
+      { 'tracks' => tracks }
+    end
+
+    # 回帰ガードのテスト用: playable 2件 + null 1件（対象抽出SQLの「一部null」条件にも合致する）。
+    def payload_with_two_playable_and_one_null_track
+      tracks = [
+        complete_track(track_number: 1),
+        complete_track(track_number: 2),
+        degraded_track(track_number: 3)
+      ]
+      payload_with_tracks(tracks)
+    end
+
+    # 回帰ガードのテスト用: 既存のplayable 2件より少ないplayable 1件だけを返すfetch結果。
+    def build_regressed_album
+      build_fixed_album(
+        tracks_payload: [{ 'track_number' => 1, 'video_id' => 'v1', 'playlist_id' => 'pl1', 'title' => 'T' }]
+      )
+    end
+
+    def complete_track(track_number:, video_id: "vid-#{SecureRandom.hex(4)}")
+      {
+        'track_number' => track_number, 'video_id' => video_id, 'playlist_id' => 'PL123', 'title' => 'Track',
+        'url' => "https://music.youtube.com/watch?v=#{video_id}&list=PL123"
+      }
+    end
+
+    def degraded_track(track_number:)
+      { 'track_number' => track_number, 'video_id' => nil, 'playlist_id' => nil, 'title' => 'Track' }
+    end
+
+    def track_with_zero_track_number(track_number: 0, video_id: "vid-#{SecureRandom.hex(4)}")
+      { 'track_number' => track_number, 'video_id' => video_id, 'playlist_id' => 'PL123', 'title' => 'Track' }
+    end
+
+    def track_with_null_track_number(video_id: "vid-#{SecureRandom.hex(4)}")
+      { 'track_number' => nil, 'video_id' => video_id, 'playlist_id' => 'PL123', 'title' => 'Track' }
+    end
+
+    def create_album
+      Album.create!(jan_code: "repair-#{SecureRandom.hex(6)}")
+    end
+
+    def create_track(album)
+      Track.create!(album:, isrc: "JPRP#{SecureRandom.alphanumeric(8).upcase}")
+    end
+
+    def create_ytmusic_album(payload:, album: create_album, browse_id: "repair-browse-#{SecureRandom.hex(4)}")
+      YtmusicAlbum.create!(album:, browse_id:, name: 'Repair Target Album', payload:)
+    end
+
+    def create_ytmusic_track(ytmusic_album:, album:, track:, track_number:, name:)
+      YtmusicTrack.create!(
+        album:, ytmusic_album:, track:, track_number:, name:,
+        video_id: "old-#{SecureRandom.hex(4)}", playlist_id: "oldpl-#{SecureRandom.hex(4)}",
+        payload: { 'video_id' => 'old' }
+      )
+    end
+  end
+end

--- a/test/lib/yt_music/album_test.rb
+++ b/test/lib/yt_music/album_test.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module YtMusic
+  class AlbumTest < ActiveSupport::TestCase
+    FakeTrack = Struct.new(:playable) do
+      def playable?
+        playable
+      end
+    end
+
+    test 'degraded? is false when at least one track is playable' do
+      album = build_album_with_tracks([FakeTrack.new(true), FakeTrack.new(false)])
+
+      assert_not album.degraded?
+    end
+
+    test 'degraded? is true when no tracks are playable' do
+      album = build_album_with_tracks([FakeTrack.new(false), FakeTrack.new(false)])
+
+      assert_predicate album, :degraded?
+    end
+
+    test 'degraded? is true when tracks is empty' do
+      album = build_album_with_tracks([])
+
+      assert_predicate album, :degraded?
+    end
+
+    test 'degraded? is true when tracks is nil' do
+      album = build_album_with_tracks(nil)
+
+      assert_predicate album, :degraded?
+    end
+
+    test 'playable_track_count counts only playable tracks' do
+      album = build_album_with_tracks([FakeTrack.new(true), FakeTrack.new(true), FakeTrack.new(false)])
+
+      assert_equal 2, album.playable_track_count
+    end
+
+    test 'playable_track_count is 0 when tracks is nil' do
+      album = build_album_with_tracks(nil)
+
+      assert_equal 0, album.playable_track_count
+    end
+
+    test 'playable_track_count is 0 when tracks is empty' do
+      album = build_album_with_tracks([])
+
+      assert_equal 0, album.playable_track_count
+    end
+
+    test 'degraded? is false via real Track parsing when playlist_id is missing on every track' do
+      response = build_response(
+        artist_texts: ['Album Artist'],
+        track_artist_texts: [nil, nil],
+        track_playlist_ids: [nil, nil]
+      )
+
+      album = Album.new(response)
+
+      assert_equal [nil, nil], album.tracks.map(&:playlist_id)
+      assert(album.tracks.all? { |track| track.video_id.present? && track.track_number.to_i.positive? })
+      assert_not album.degraded?
+    end
+
+    test 'tracks without their own artist column inherit the album artists' do
+      response = build_response(
+        artist_texts: ['Album Artist'],
+        track_artist_texts: [nil, nil]
+      )
+
+      album = Album.new(response)
+
+      assert_equal ['Album Artist'], album.artists.map(&:name)
+      album.tracks.each do |track|
+        assert_equal album.artists, track.artists
+      end
+    end
+
+    test 'missing straplineTextOne still sets tracks, thumbnails and playlist_url, with artists empty' do
+      response = build_response(artist_texts: nil, track_artist_texts: [nil])
+
+      album = Album.new(response)
+
+      assert_equal [], album.artists
+      assert_equal 1, album.tracks.size
+      assert_equal 1, album.thumbnails.size
+      assert_equal 'https://music.youtube.com/playlist?list=test', album.playlist_url
+    end
+
+    private
+
+    def build_album_with_tracks(tracks)
+      Album.allocate.tap { it.instance_variable_set(:@tracks, tracks) }
+    end
+
+    def build_response(artist_texts:, track_artist_texts:, track_playlist_ids: nil)
+      strapline = if artist_texts.nil?
+                    nil
+                  else
+                    { 'runs' => artist_texts.map { |text| { 'text' => text } } }
+                  end
+
+      header = {
+        'title' => { 'runs' => [{ 'text' => 'Album Title' }] },
+        'subtitle' => { 'runs' => [{ 'text' => 'アルバム' }, { 'text' => ' • ' }, { 'text' => '2026' }] },
+        'straplineTextOne' => strapline,
+        'secondSubtitle' => { 'runs' => [{ 'text' => track_artist_texts.size.to_s }, { 'text' => ' • ' }, { 'text' => '10:00' }] },
+        'thumbnail' => {
+          'musicThumbnailRenderer' => {
+            'thumbnail' => { 'thumbnails' => [{ 'url' => 'https://example.com/thumb.jpg', 'width' => 100, 'height' => 100 }] }
+          }
+        }
+      }
+
+      track_playlist_ids ||= Array.new(track_artist_texts.size, 'PLAYLIST')
+      track_contents = track_artist_texts.each_with_index.map { |texts, index| build_track_item(texts, playlist_id: track_playlist_ids[index]) }
+
+      {
+        'contents' => {
+          'twoColumnBrowseResultsRenderer' => {
+            'tabs' => [
+              {
+                'tabRenderer' => {
+                  'content' => {
+                    'sectionListRenderer' => {
+                      'contents' => [
+                        { 'musicResponsiveHeaderRenderer' => header }
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            'secondaryContents' => {
+              'sectionListRenderer' => {
+                'contents' => [
+                  { 'musicShelfRenderer' => { 'contents' => track_contents } }
+                ]
+              }
+            }
+          }
+        },
+        'microformat' => {
+          'microformatDataRenderer' => { 'urlCanonical' => 'https://music.youtube.com/playlist?list=test' }
+        }
+      }
+    end
+
+    def build_track_item(artist_texts, playlist_id: 'PLAYLIST')
+      flex_columns = [
+        {
+          'musicResponsiveListItemFlexColumnRenderer' => {
+            'text' => { 'runs' => [{ 'text' => 'Track Title', 'navigationEndpoint' => { 'watchEndpoint' => { 'videoId' => 'VIDEO', 'playlistId' => playlist_id } } }] }
+          }
+        }
+      ]
+      flex_columns[1] = {
+        'musicResponsiveListItemFlexColumnRenderer' => {
+          'text' => artist_texts.nil? ? {} : { 'runs' => artist_texts.map { |text| { 'text' => text } } }
+        }
+      }
+
+      {
+        'musicResponsiveListItemRenderer' => {
+          'flexColumns' => flex_columns,
+          'fixedColumns' => [
+            { 'musicResponsiveListItemFixedColumnRenderer' => { 'text' => { 'runs' => [{ 'text' => '3:30' }] } } }
+          ],
+          'index' => { 'runs' => [{ 'text' => '1' }] }
+        }
+      }
+    end
+  end
+end

--- a/test/lib/yt_music/album_test.rb
+++ b/test/lib/yt_music/album_test.rb
@@ -91,7 +91,52 @@ module YtMusic
       assert_equal 'https://music.youtube.com/playlist?list=test', album.playlist_url
     end
 
+    test 'find returns nil without raising when the response has neither contents nor error (deleted/unwatchable album)' do
+      response = { 'responseContext' => {}, 'trackingParams' => 'xxx', 'microformat' => {} }
+
+      result = nil
+      with_stubbed_base_find(response) do
+        result = Album.find('MPREb_dummy')
+      end
+
+      assert_nil result
+    end
+
+    test 'find returns nil when the response has an error key' do
+      response = { 'error' => { 'code' => 404 } }
+
+      result = nil
+      with_stubbed_base_find(response) do
+        result = Album.find('MPREb_dummy')
+      end
+
+      assert_nil result
+    end
+
+    test 'find returns an Album instance for a normal response' do
+      response = build_response(artist_texts: ['Album Artist'], track_artist_texts: [nil, nil])
+
+      result = nil
+      with_stubbed_base_find(response) do
+        result = Album.find('MPREb_dummy')
+      end
+
+      assert_instance_of Album, result
+    end
+
     private
+
+    # YtMusic::Base.findの特異メソッドを一時的に差し替え、Album.find内部の`super(id, 'album')`が
+    # 任意のレスポンスを返すようにする。Album.findがsuperで呼ぶのはクラスメソッドのため、
+    # stub_constでBase定数自体を差し替えても継承チェーンには影響せず効かない。
+    def with_stubbed_base_find(response)
+      singleton_class = YtMusic::Base.singleton_class
+      original_method = singleton_class.instance_method(:find)
+      singleton_class.define_method(:find) { |*_args| response }
+      yield
+    ensure
+      singleton_class.define_method(:find, original_method)
+    end
 
     def build_album_with_tracks(tracks)
       Album.allocate.tap { it.instance_variable_set(:@tracks, tracks) }

--- a/test/lib/yt_music/response_test.rb
+++ b/test/lib/yt_music/response_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module YtMusic
+  class ResponseTest < ActiveSupport::TestCase
+    test 'collects only the album shelf when other shelf types are present' do
+      shelves = [
+        { 'itemSectionRenderer' => {} },
+        { 'musicCardShelfRenderer' => { 'title' => { 'runs' => [{ 'text' => 'アルバム' }] } } },
+        build_album_shelf(['Album One'])
+      ]
+      response = Response.new(build_raw_response(shelves))
+
+      assert_equal ['Album One'], response.data[:albums].map(&:title)
+    end
+
+    test 'returns an empty hash without raising when contents is nil' do
+      raw_response = { 'contents' => nil }
+
+      response = Response.new(raw_response)
+
+      assert_equal({}, response.data)
+    end
+
+    test 'returns an empty hash without raising when the tabbed contents path is missing entirely' do
+      response = Response.new({})
+
+      assert_equal({}, response.data)
+    end
+
+    private
+
+    def build_raw_response(contents)
+      {
+        'contents' => {
+          'tabbedSearchResultsRenderer' => {
+            'tabs' => [
+              {
+                'tabRenderer' => {
+                  'content' => {
+                    'sectionListRenderer' => { 'contents' => contents }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    end
+
+    def build_album_shelf(titles)
+      {
+        'musicShelfRenderer' => {
+          'title' => { 'runs' => [{ 'text' => 'アルバム' }] },
+          'contents' => titles.map { |title| { 'musicResponsiveListItemRenderer' => build_simple_album_item(title) } }
+        }
+      }
+    end
+
+    def build_simple_album_item(title)
+      {
+        'flexColumns' => [
+          {
+            'musicResponsiveListItemFlexColumnRenderer' => {
+              'text' => { 'runs' => [{ 'text' => title }] }
+            }
+          },
+          {
+            'musicResponsiveListItemFlexColumnRenderer' => {
+              'text' => { 'runs' => [{ 'text' => 'アルバム' }, { 'text' => ' • ' }, { 'text' => '2026' }] }
+            }
+          }
+        ]
+      }
+    end
+  end
+end

--- a/test/lib/yt_music/track_test.rb
+++ b/test/lib/yt_music/track_test.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module YtMusic
+  class TrackTest < ActiveSupport::TestCase
+    test 'extracts video_id, playlist_id and track_number from a normal response' do
+      track = Track.new(build_content(
+                          flex_navigation: { 'videoId' => 'VIDEO1', 'playlistId' => 'PLAYLIST1' },
+                          index_text: '1'
+                        ))
+
+      assert_equal 'VIDEO1', track.video_id
+      assert_equal 'PLAYLIST1', track.playlist_id
+      assert_equal 1, track.track_number
+      assert_predicate track, :complete?
+    end
+
+    test 'falls back to playlistItemData for video_id when flexColumn navigationEndpoint is missing' do
+      track = Track.new(build_content(
+                          flex_navigation: nil,
+                          playlist_item_data: { 'videoId' => 'VIDEO2' },
+                          index_text: '2'
+                        ))
+
+      assert_equal 'VIDEO2', track.video_id
+      assert_nil track.playlist_id
+      assert_not track.complete?
+    end
+
+    test 'falls back to the overlay play button when flexColumn and playlistItemData are missing' do
+      track = Track.new(build_content(
+                          flex_navigation: nil,
+                          playlist_item_data: nil,
+                          overlay_navigation: { 'videoId' => 'VIDEO3', 'playlistId' => 'PLAYLIST3' },
+                          index_text: '3'
+                        ))
+
+      assert_equal 'VIDEO3', track.video_id
+      assert_equal 'PLAYLIST3', track.playlist_id
+      assert_equal 3, track.track_number
+      assert_predicate track, :complete?
+    end
+
+    test 'track_number is nil without raising when index is missing' do
+      track = Track.new(build_content(
+                          flex_navigation: { 'videoId' => 'VIDEO4', 'playlistId' => 'PLAYLIST4' },
+                          index_text: nil
+                        ))
+
+      assert_nil track.track_number
+      assert_not track.complete?
+    end
+
+    test 'playable? is true when video_id and track_number are present even without playlist_id' do
+      track = Track.new(build_content(
+                          flex_navigation: { 'videoId' => 'VIDEO5' },
+                          index_text: '1'
+                        ))
+
+      assert_nil track.playlist_id
+      assert_predicate track, :playable?
+    end
+
+    test 'playable? is false when video_id is missing' do
+      track = Track.new(build_content(
+                          flex_navigation: nil,
+                          index_text: '1'
+                        ))
+
+      assert_not track.playable?
+    end
+
+    test 'playable? is false when track_number is nil' do
+      track = Track.new(build_content(
+                          flex_navigation: { 'videoId' => 'VIDEO6', 'playlistId' => 'PLAYLIST6' },
+                          index_text: nil
+                        ))
+
+      assert_not track.playable?
+    end
+
+    test 'playable? is false when track_number is 0' do
+      track = Track.new(build_content(
+                          flex_navigation: { 'videoId' => 'VIDEO7', 'playlistId' => 'PLAYLIST7' },
+                          index_text: '0'
+                        ))
+
+      assert_not track.playable?
+    end
+
+    test 'uses the track-specific artist column when present, ignoring album_artists' do
+      album_artists = [Artist.new({ 'text' => 'Album Artist' })]
+      track = Track.new(
+        build_content(artist_texts: ['Track Artist']),
+        album_artists:
+      )
+
+      assert_equal ['Track Artist'], track.artists.map(&:name)
+    end
+
+    test 'falls back to album_artists when the track has no artist column runs' do
+      album_artists = [Artist.new({ 'text' => 'Album Artist' })]
+      track = Track.new(build_content(artist_texts: nil), album_artists:)
+
+      assert_equal album_artists, track.artists
+    end
+
+    test 'artists is nil when neither the track nor album_artists provide artists' do
+      track = Track.new(build_content(artist_texts: nil))
+
+      assert_nil track.artists
+    end
+
+    test 'extracts a plain integer view_count from "再生回数 17 回"' do
+      track = Track.new(build_content(view_count_text: '再生回数 17 回'))
+
+      assert_equal '再生回数 17 回', track.view_count_text
+      assert_equal 17, track.view_count
+    end
+
+    test 'extracts view_count in 万 units from "再生回数 1.2万 回"' do
+      track = Track.new(build_content(view_count_text: '再生回数 1.2万 回'))
+
+      assert_equal 12_000, track.view_count
+    end
+
+    test 'extracts view_count in 万 units from "再生回数 2302万 回"' do
+      track = Track.new(build_content(view_count_text: '再生回数 2302万 回'))
+
+      assert_equal 23_020_000, track.view_count
+    end
+
+    test 'extracts view_count with a fractional 万 unit from "再生回数 6.5万 回"' do
+      track = Track.new(build_content(view_count_text: '再生回数 6.5万 回'))
+
+      assert_equal 65_000, track.view_count
+    end
+
+    test 'extracts view_count from a comma-separated number "再生回数 1,234 回"' do
+      track = Track.new(build_content(view_count_text: '再生回数 1,234 回'))
+
+      assert_equal 1234, track.view_count
+    end
+
+    test 'view_count is nil when the text has no digits at all' do
+      track = Track.new(build_content(view_count_text: 'アーティスト名'))
+
+      assert_equal 'アーティスト名', track.view_count_text
+      assert_nil track.view_count
+    end
+
+    test 'view_count_text and view_count are nil when flexColumns[2] is missing' do
+      track = Track.new(build_content(view_count_text: nil))
+
+      assert_nil track.view_count_text
+      assert_nil track.view_count
+    end
+
+    private
+
+    def build_content(flex_navigation: nil, playlist_item_data: nil, overlay_navigation: nil, **extra)
+      flex_run = { 'text' => 'Song Title' }
+      flex_run['navigationEndpoint'] = { 'watchEndpoint' => flex_navigation } if flex_navigation
+
+      flex_columns = [
+        {
+          'musicResponsiveListItemFlexColumnRenderer' => {
+            'text' => { 'runs' => [flex_run] }
+          }
+        }
+      ]
+      flex_columns[1] = build_artist_column(extra[:artist_texts]) if extra.key?(:artist_texts)
+      flex_columns[2] = build_view_count_column(extra[:view_count_text]) if extra.key?(:view_count_text)
+
+      item = { 'flexColumns' => flex_columns }
+      item['playlistItemData'] = playlist_item_data if playlist_item_data
+      if overlay_navigation
+        item['overlay'] = {
+          'musicItemThumbnailOverlayRenderer' => {
+            'content' => {
+              'musicPlayButtonRenderer' => {
+                'playNavigationEndpoint' => { 'watchEndpoint' => overlay_navigation }
+              }
+            }
+          }
+        }
+      end
+      item['index'] = { 'runs' => [{ 'text' => extra[:index_text] }] } if extra[:index_text]
+
+      { 'musicResponsiveListItemRenderer' => item }
+    end
+
+    def build_artist_column(artist_texts)
+      runs = artist_texts&.map { |text| { 'text' => text } }
+
+      {
+        'musicResponsiveListItemFlexColumnRenderer' => {
+          'text' => runs ? { 'runs' => runs } : {}
+        }
+      }
+    end
+
+    def build_view_count_column(view_count_text)
+      return nil if view_count_text.nil?
+
+      {
+        'musicResponsiveListItemFlexColumnRenderer' => {
+          'text' => { 'runs' => [{ 'text' => view_count_text }] }
+        }
+      }
+    end
+  end
+end

--- a/test/models/ytmusic_album_process_jan_to_album_browse_ids_test.rb
+++ b/test/models/ytmusic_album_process_jan_to_album_browse_ids_test.rb
@@ -12,6 +12,10 @@ class YtmusicAlbumProcessJanToAlbumBrowseIdsTest < ActiveSupport::TestCase
         'year' => year
       }
     end
+
+    def degraded?
+      false
+    end
   end
 
   test 'creates YouTube Music album from JAN_TO_ALBUM_BROWSE_IDS' do

--- a/test/models/ytmusic_album_test.rb
+++ b/test/models/ytmusic_album_test.rb
@@ -3,9 +3,14 @@
 require 'test_helper'
 
 class YtmusicAlbumTest < ActiveSupport::TestCase
-  YtmusicApiAlbum = Struct.new(:title, :playlist_url, :track_total_count, :year, keyword_init: true) do
+  YtmusicApiAlbum = Struct.new(:title, :playlist_url, :track_total_count, :year, :degraded, :playable_track_count,
+                               keyword_init: true) do
     def as_json(*)
       { 'title' => title, 'year' => year, 'artists' => [] }
+    end
+
+    def degraded?
+      degraded
     end
   end
 
@@ -28,6 +33,118 @@ class YtmusicAlbumTest < ActiveSupport::TestCase
     assert_equal '東方猫鍵盤 9', @ytmusic_album.reload.name
     assert_equal 12, @ytmusic_album.total_tracks
     assert_equal "https://music.youtube.com/browse/#{browse_id}", @ytmusic_album.url
+  end
+
+  test 'save_album does not create a record when the album is degraded' do
+    album = Album.create!(jan_code: "ytmusic-album-degraded-save-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+
+    result = nil
+    assert_no_difference -> { YtmusicAlbum.unscoped.count } do
+      result = YtmusicAlbum.save_album(album.id, browse_id, build_api_album(degraded: true))
+    end
+
+    assert_nil result
+    assert_not YtmusicAlbum.unscoped.exists?(browse_id:)
+  end
+
+  test 'save_album creates a record as usual when the album is not degraded' do
+    album = Album.create!(jan_code: "ytmusic-album-normal-save-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+
+    result = nil
+    assert_difference -> { YtmusicAlbum.unscoped.count }, 1 do
+      result = YtmusicAlbum.save_album(album.id, browse_id, build_api_album(title: '通常アルバム'))
+    end
+
+    assert_equal '通常アルバム', result.name
+  end
+
+  test 'update_album does not overwrite the payload when the album is degraded' do
+    album = Album.create!(jan_code: "ytmusic-album-degraded-update-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+    ytmusic_album = YtmusicAlbum.save_album(album.id, browse_id, build_api_album(title: '既存アルバム'))
+    original_payload = ytmusic_album.reload.payload
+
+    result = ytmusic_album.update_album(
+      build_api_album(title: '劣化アルバム', degraded: true),
+      "https://music.youtube.com/browse/#{browse_id}"
+    )
+
+    assert_not result
+    assert_equal original_payload, ytmusic_album.reload.payload
+    assert_equal '既存アルバム', ytmusic_album.name
+  end
+
+  test 'update_album updates as usual when the album is not degraded' do
+    album = Album.create!(jan_code: "ytmusic-album-normal-update-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+    ytmusic_album = YtmusicAlbum.save_album(album.id, browse_id, build_api_album(title: '更新前アルバム'))
+
+    result = ytmusic_album.update_album(
+      build_api_album(title: '更新後アルバム'),
+      "https://music.youtube.com/browse/#{browse_id}"
+    )
+
+    assert result
+    assert_equal '更新後アルバム', ytmusic_album.reload.name
+  end
+
+  test 'update_album rejects a fetch result with fewer playable tracks than the existing payload (regression guard)' do
+    album = Album.create!(jan_code: "ytmusic-album-regression-decrease-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+    ytmusic_album = YtmusicAlbum.create!(album:, browse_id:, name: '既存アルバム', payload: playable_tracks_payload(10))
+
+    result = ytmusic_album.update_album(
+      build_api_album(title: '悪化アルバム', playable_track_count: 8),
+      "https://music.youtube.com/browse/#{browse_id}"
+    )
+
+    assert_not result
+    assert_equal '既存アルバム', ytmusic_album.reload.name
+    assert_equal playable_tracks_payload(10), ytmusic_album.payload
+  end
+
+  test 'update_album updates when the playable track count stays the same (regression guard allows equal)' do
+    album = Album.create!(jan_code: "ytmusic-album-regression-same-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+    ytmusic_album = YtmusicAlbum.create!(album:, browse_id:, name: '既存アルバム', payload: playable_tracks_payload(10))
+
+    result = ytmusic_album.update_album(
+      build_api_album(title: '更新後アルバム', playable_track_count: 10),
+      "https://music.youtube.com/browse/#{browse_id}"
+    )
+
+    assert result
+    assert_equal '更新後アルバム', ytmusic_album.reload.name
+  end
+
+  test 'update_album updates when the playable track count increases (regression guard allows improvement)' do
+    album = Album.create!(jan_code: "ytmusic-album-regression-increase-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+    ytmusic_album = YtmusicAlbum.create!(album:, browse_id:, name: '既存アルバム', payload: playable_tracks_payload(10))
+
+    result = ytmusic_album.update_album(
+      build_api_album(title: '更新後アルバム', playable_track_count: 12),
+      "https://music.youtube.com/browse/#{browse_id}"
+    )
+
+    assert result
+    assert_equal '更新後アルバム', ytmusic_album.reload.name
+  end
+
+  test 'update_album updates even with few playable tracks when the existing payload has no tracks (regression guard does not apply)' do
+    album = Album.create!(jan_code: "ytmusic-album-regression-empty-#{SecureRandom.hex(4)}")
+    browse_id = "MPREb_#{SecureRandom.hex(4)}"
+    ytmusic_album = YtmusicAlbum.create!(album:, browse_id:, name: '既存アルバム', payload: {})
+
+    result = ytmusic_album.update_album(
+      build_api_album(title: '更新後アルバム', playable_track_count: 1),
+      "https://music.youtube.com/browse/#{browse_id}"
+    )
+
+    assert result
+    assert_equal '更新後アルバム', ytmusic_album.reload.name
   end
 
   test 'reports progress while fetching YouTube Music albums' do
@@ -55,12 +172,18 @@ class YtmusicAlbumTest < ActiveSupport::TestCase
 
   private
 
+  def playable_tracks_payload(count)
+    { 'tracks' => Array.new(count) { |i| { 'video_id' => "v#{i}", 'track_number' => i + 1 } } }
+  end
+
   def build_api_album(**attributes)
     YtmusicApiAlbum.new(
       title: 'YouTube Music Album',
       playlist_url: 'https://music.youtube.com/playlist?list=test',
       track_total_count: 10,
       year: '2026',
+      degraded: false,
+      playable_track_count: attributes[:degraded] ? 0 : 10,
       **attributes
     )
   end


### PR DESCRIPTION
## 概要

`ytmusic_albums` 3,742件のうち **2,176件**で `payload` の `tracks` から `video_id` / `playlist_id` / `track_number` が欠落していた問題を修復し、同じ事故が二度と起きない構造を入れました。

当初は「パーサが壊れている」という見立てでしたが、**パーサのパス自体は壊れていませんでした**。劣化した `browse_id` を再取得すると現行パーサで完全なデータが取得できます。

## 根本原因

2025-08-02 の一括更新（`UpdateAllYtmusicAlbumPayloads`）で、YouTube 側がスロットリング時に返す**縮退レスポンス**（トラック行から `flexColumns[0].…navigationEndpoint` と `index` が欠けたもの）を受け取り、`YtmusicAlbum#update_album` が**取得内容を検証せず payload を無条件で上書き**したことが原因です。

- 劣化トラック 20,492件は**全件が `video_id: null` / `playlist_id: null` / `track_number: 0`** という同一パターン
- アルバム側フィールド（title / artists / thumbnails / playlist_url / year / track_total_count）は全件正常
- 発生は 2025-08-02 の1回のみ（その日更新2,813件中2,167件が劣化）。翌 8/3 の 44f51e6 で `track_number == 0` の `raise` が入り再発は止まったが、**既に壊れた2,176件は誰も修復していなかった**

## パーサ陳腐化の実測

`lib/yt_music/` の全抽出パスをライブレスポンスで監査しました（browse 14件=162トラック / search 5クエリ / player 5本）。

| 対象 | 結果 |
|---|---|
| Album header（title / type / subtitle / straplineTextOne / secondSubtitle / thumbnails / playlist_url / tracks shelf） | 14/14 正常 |
| Search（tabbedSearchResults → musicShelfRenderer → カテゴリ「アルバム」） | 5/5 正常 |
| SimpleAlbum（browse_id / title / type / year / artists） | 5/5 正常 |
| Track（title / video_id / playlist_id / track_number / duration） | 162/162 正常 |
| Video（videoDetails / microformat / publishDate / uploadDate / "Released on:"） | 5/5 正常 |

一方、**実際に陳腐化していた箇所を2件**発見しました。

1. **トラック別アーティスト列 `flexColumns[1]`** — 単一アーティストのアルバムでは `text.runs` が存在せず、代わりに **`flexColumns[2]` に再生回数**が入る新レイアウトになっていた。162トラック中ヒット21件のみ。これが `ytmusic_tracks` 35,619件中 33,921件（95%）で `payload.artists` が空だった原因。
2. **`YtMusic::Response#parser`** — `itemSectionRenderer` でも `musicShelfRenderer` でもないシェルフ（`musicCardShelfRenderer` 等）が来ると `ctx.dig` で `NoMethodError` になるクラッシュ経路が存在。

## 変更内容

### パーサの堅牢化・最新化（`lib/yt_music/`）

- `Track#video_id` を3経路からフォールバック取得（`flexColumns[0].navigationEndpoint` → `playlistItemData` → `overlay.playNavigationEndpoint`）。`playlist_id` も2経路。
- `track_number` は取得できない場合 `0` ではなく `nil` を返す。配列位置からの推測はしない（マルチディスクアルバムの誤マッチを避けるため）。
- `raise ArgumentError, "Invalid track number: 0"` を廃止。パーサは例外を投げず、保護は保存側のバリデーションに一本化。
- `Track#playable?`（`video_id` + `track_number`）と `Track#complete?`（+ `playlist_id`）を追加。
- **トラックにアーティスト列が無い場合、アルバムのアーティストへフォールバック**するよう変更。
- **`flexColumns[2]` の再生回数を `view_count` / `view_count_text` として取得**（`千` / `万` / `億` の概数表記、全角数字、桁区切りに対応。数字を含まない文字列は `nil`）。
- `Album#degraded?` / `Album#playable_track_count` を追加。
- `Album#initialize` の `straplineTextOne` 欠落時の早期 return を廃止し、`tracks` / `thumbnails` / `playlist_url` が必ず設定されるよう変更。
- `Response#parser` に `contents` 欠落と非 `musicShelfRenderer` シェルフへの防御を追加。

### 消滅アルバムの安全な処理

`YtMusic::Album.find` が、YouTube 上から削除されたアルバム（`error` キーも `contents` キーも持たないレスポンス）を検知して `nil` を返すよう修正しました。従来は `header` が nil のまま `dig` を呼び `NoMethodError` で落ちていました。全件再取得で**5件**該当しています。

- ヘッダ抽出を `extract_header` に一本化し、`find` と `initialize` で共有（同じパスを2箇所に書かない）
- `find` を経由しない直接生成では原因の分かる `ArgumentError` を送出（`NoMethodError` にしない）
- アルバム消滅は再試行しても回復しないため、リトライせず即座に「取得失敗」として計上

### 保存時のバリデーション（`app/models/ytmusic_album.rb`）

二段構えで「既存 payload より悪いデータで上書きする」ことを構造的に不可能にしました。

1. **縮退検出** — 全トラックが `playable?` でない（＝完全な取得失敗）なら payload を一切変更せず `false` を返す
2. **回帰ガード** — 既存 payload の再生可能トラック数を下回る取得結果は payload を一切変更せず `false` を返す

「1トラックでも欠けたら拒否」にはしていません。YouTube 側で1曲だけ配信停止になったアルバムが**永久に更新不能になる**のを避けるためで、実際にこの設計に至る過程で、`playlist_id` が正当に欠ける10アルバムが「壊れた古い payload を温存し続ける」状態になることを実測で確認しています。

`admin/actions.rb` の `UpdateAllYtmusicAlbumPayloads` / `UpdateYtmusicAlbumPayload` も、スキップをエラー計上して理由が分かるようにしました。

### 修復ツール（`lib/repair/ytmusic_album_payloads.rb` + rake タスク）

```bash
# dry-run（既定）— 対象件数と内訳を表示するだけ。APIを一切叩かない
devbox run -- bin/rails ytmusic:repair_degraded_album_payloads

# 実行
devbox run -- bin/rails ytmusic:repair_degraded_album_payloads APPLY=1

# 動作確認用に件数を絞る / ytmusic_tracks も同期する / リトライ回数を変える
devbox run -- bin/rails ytmusic:repair_degraded_album_payloads APPLY=1 LIMIT=20 SYNC_TRACKS=1 MAX_ATTEMPTS=5

# 全件モード: 劣化の有無に関わらず全アルバムを再取得し、payload を最新パーサの形式に揃える
devbox run -- bin/rails ytmusic:repair_degraded_album_payloads ALL=1 APPLY=1
```

`ALL=1` は回帰ガードにより既存 payload が悪化することが構造的に起きないため安全に実行できます。dry-run の内訳には「劣化なし」の分類も表示されます。

- 対象は SQL（`video_id` が null、または `track_number` が欠落/0 のトラックを含む行）で絞り込み、`id` のみ `pluck`
- `ParallelRunner`（既定7並列プロセス）で処理。ワーカー数は `PARALLEL_WORKERS` で上書き可
- **縮退を検出したら指数バックオフ＋ジッタで最大3回リトライ**し、それでも縮退なら**保存せずスキップ**して既存 payload を温存
- 冪等（修復済みは次回の対象に入らない）。スキップした `browse_id` はサマリに最大10件表示

### その他

- rake タスクの `YTMusic::Album`（誤記）を `YtMusic::Album` に修正（`fetch_albums` / `update_album_and_tracks` が現状壊れていた）

## 修復実績（実測）

| 指標 | 修復前 | 劣化分のみ修復 | **全件再取得後** |
|---|---|---|---|
| `video_id` が null のトラック | 20,492 | 0 | **0** |
| `track_number` が欠落/0 のトラック | 20,495 | 0 | **0** |
| 劣化アルバム | 2,176 | 0 | **0** |
| `payload.artists` あり（トラック単位） | 13% 相当 | 61.2% | **99.9%**（35,816/35,856）|
| `payload.view_count` あり | 0% | 59.6% | **99.1%**（35,546/35,856）|
| `payload.playlist_id` あり | — | 99.6% | 99.3% |
| アルバム数 / 子トラック数 | 3,742 / 35,619 | — | 3,742 / 35,619（消失なし）|
| `payload` の必須キー（title/artists/tracks/thumbnails/playlist_url） | — | — | 3,742/3,742 全件 |

- 劣化分2,157件を計 **94.4秒**で修復（7並列プロセス）
- その後 `ALL=1` で全3,742件を **140.0秒**で再取得。修復3,737件 / 縮退スキップ0件 / **エラー0件**
- 残る5件は **YouTube 上からアルバムが削除済み**のもので、「取得失敗」として計上され既存 payload は温存されています。未充足の40トラック（artists）はこの5件に対応します
- `release_year` は全件4桁で不変、`url` / `playlist_url` の null なし

`playlist_id` が 99.6% → 99.3% にわずかに下がっているのは、`playlist_id` を持たないトラックが正当に存在する（同一アルバム内でも [Instrumental] 版だけ欠ける等）ためで、最新のレスポンスをそのまま反映した結果です。`video_id` と `track_number` は 100% 揃っています。

## テスト

```
255 runs, 1374 assertions, 0 failures, 0 errors, 0 skips
227 files inspected, no offenses detected
```

新規テスト: `test/lib/yt_music/track_test.rb` / `album_test.rb` / `response_test.rb`、`test/lib/repair/ytmusic_album_payloads_test.rb`。外部APIは一切叩かず、ローカルのハッシュとスタブで完結しています。

## 残課題（本PRのスコープ外）

- **`ytmusic_tracks` 35,619件の payload は旧形式のまま**（`artists` が95%欠落）。`SYNC_TRACKS=1` または別タスクで同期可能
- **YouTube 上から削除された5アルバム**（`MPREb_OViFvZxDf7Q` / `MPREb_UQkDpVijIrc` / `MPREb_HnSW1DIXl0T` / `MPREb_m0Wf9wcR9Ym` / `MPREb_YliLHshW0qS`）は既存 payload を温存したまま。配信終了として扱うか削除するかは別途判断が必要
- `ytmusic_tracks` のマルチディスクアルバム誤マッチ153行（#565 で既知課題としたもの）は未着手
