### PR TITLE
[Spotify移行 1/4] SpotifyApi クライアント層の新設

### DIFF
--- a/config/initializers/spotify_api.rb
+++ b/config/initializers/spotify_api.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/spotify_api')
+
+# ここではアクセストークンを取得しない。
+#
+# 起動時にネットワークI/Oを走らせると、Spotify 側の障害時に bin/rails の
+# あらゆるコマンドが遅くなる・起動できなくなるため、トークンは最初の
+# API 呼び出し時に SpotifyApi::Config#access_token が遅延取得する。
+SpotifyApi.configure do |config|
+  config.client_id           = ENV.fetch('SPOTIFY_CLIENT_ID', nil)
+  config.client_secret       = ENV.fetch('SPOTIFY_CLIENT_SECRET', nil)
+  config.market              = 'JP'
+  config.search_limit        = ENV.fetch('SPOTIFY_SEARCH_LIMIT', 50).to_i
+  config.playlist_items_path = ENV.fetch('SPOTIFY_PLAYLIST_ITEMS_PATH', 'tracks')
+end

--- a/lib/external_api/connection.rb
+++ b/lib/external_api/connection.rb
@@ -19,6 +19,8 @@ module ExternalApi
     #   尊重されるかどうかもこの指定に依存する。
     #   つまり retry_statuses を省略すると、429 のレート制限はリトライされず
     #   Retry-After も無視される。
+    #   この共通設定はプロファイル側の retry に同じキーを書くことで上書きできる
+    #   （build 内のマージ順が **SHARED_RETRY_OPTIONS, **profile[:retry] のため）。
     #
     # exceptions について:
     #   接続断・タイムアウト系は再送で回復する見込みがあるためリトライ対象に含める。
@@ -63,6 +65,34 @@ module ExternalApi
         open_timeout: 5,
         timeout: 30,
         retry: { max: 2, interval: 1.0, backoff_factor: 2, max_interval: 10, interval_randomness: 0.5, methods: %i[get] }
+      },
+      # spotify だけ retry_statuses から 429 を意図的に除外している。
+      #   Spotify は Development Mode のクォータ超過時に Retry-After: 64063（約17.8時間）のような
+      #   極端な値を返すことがあり、faraday-retry はその値ぶんスレッドをブロックして待機してしまう。
+      #   429 のハンドリングは既存の SpotifyRetry / SpotifyRateLimit（app/models 配下）に委ね、
+      #   Faraday 層では 5xx の一時的な障害だけをリトライ対象にする。
+      spotify: {
+        open_timeout: 5,
+        timeout: 15,
+        retry: {
+          max: 3, interval: 1.0, backoff_factor: 2, max_interval: 20,
+          interval_randomness: 0.3, methods: %i[get],
+          retry_statuses: [500, 502, 503, 504]
+        }
+      },
+      # accounts.spotify.com（トークン取得）専用。
+      #   POST しかないエンドポイントであり、client_credentials / refresh_token の取得は
+      #   何度実行しても副作用がないため :post をリトライ対象に含める。
+      #   API 本体（spotify プロファイル）の POST はプレイリストへの項目追加など
+      #   非冪等な操作を含むため、そちらでは :post をリトライしない。
+      spotify_accounts: {
+        open_timeout: 5,
+        timeout: 10,
+        retry: {
+          max: 3, interval: 1.0, backoff_factor: 2, max_interval: 20,
+          interval_randomness: 0.3, methods: %i[post],
+          retry_statuses: [500, 502, 503, 504]
+        }
       }
     }.freeze
 
@@ -81,7 +111,8 @@ module ExternalApi
         Faraday.new(url ? { url: } : {}) do |conn|
           conn.options.open_timeout = profile[:open_timeout]
           conn.options.timeout = profile[:timeout]
-          conn.request :retry, **profile[:retry], **SHARED_RETRY_OPTIONS
+          # プロファイル側の指定を後に展開し、共通設定を上書きできるようにする。
+          conn.request :retry, **SHARED_RETRY_OPTIONS, **profile[:retry]
           conn.response :logger, Rails.logger, headers: false, bodies: false if Rails.env.development?
 
           block&.call(conn)

--- a/lib/spotify_api.rb
+++ b/lib/spotify_api.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# errors.rb は1ファイルに複数の例外クラスを定義しており Zeitwerk の命名規約に
+# 合わないため、ここで明示的に読み込む。
+# （AppleMusic が config.rb に ParameterMissing / ApiError を同居させているのと同じ方針）
+require_relative 'spotify_api/errors'
+
+module SpotifyApi
+  autoload :Album,         'spotify_api/album'
+  autoload :AudioFeatures, 'spotify_api/audio_features'
+  autoload :Client,        'spotify_api/client'
+  autoload :Config,        'spotify_api/config'
+  autoload :Page,          'spotify_api/page'
+  autoload :Playlist,      'spotify_api/playlist'
+  autoload :Response,      'spotify_api/response'
+  autoload :Track,         'spotify_api/track'
+  autoload :UserSession,   'spotify_api/user_session'
+
+  class << self
+    attr_writer :config
+
+    def config
+      @config ||= Config.new
+    end
+
+    def configure
+      yield(config)
+    end
+
+    # NOTE: rspotify からの移行用フィーチャーフラグ。移行完了後（Issue #563）に
+    #       このフラグと旧経路の分岐をまとめて削除する。
+    def native_client_enabled?
+      config.native_client_enabled
+    end
+  end
+end

--- a/lib/spotify_api/album.rb
+++ b/lib/spotify_api/album.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module SpotifyApi
+  # パスに先頭スラッシュを付けないこと。ベース URL が https://api.spotify.com/v1/
+  # なので、先頭スラッシュを付けると /v1 が消えてしまう（'albums/xxx' であって '/albums/xxx' ではない）。
+  class Album
+    class << self
+      # テストから Client を差し替えるための注入口（SpotifyApi::Album.client = fake_client）。
+      attr_writer :client
+
+      # market を指定すると Spotify は available_markets を返さず is_playable に
+      # 置き換わるため、既定では market を送らない。
+      #
+      # market を付けて呼び出すと SpotifyAlbum#jp_available?（app/models/spotify_album.rb）が
+      # 参照している available_markets が取得できなくなり、日本で配信中のアルバムが
+      # 「配信終了」と誤判定されて削除される危険がある。呼び出し側が明示的に
+      # market を渡したときだけ付けること。
+      def find(id, market: nil)
+        params = {}
+        params[:market] = market if market.present?
+
+        Response.build(client.get("albums/#{id}", params))
+      end
+
+      # GET /albums?ids= のバルク取得エンドポイントは2026年2月に廃止が告知されているため
+      # 使わず、1件ずつ逐次取得する。取得できなかった ID（404）は例外にせず結果から除外し
+      # warn ログを出す。それ以外の例外（429 など）はそのまま伝播させ、呼び出し側の
+      # SpotifyRetry / SpotifyRateLimit に委ねる（レート制限を握りつぶさない）。
+      def find_many(ids, market: nil)
+        ids.filter_map do |id|
+          find(id, market:)
+        rescue NotFoundError
+          Rails.logger.warn("SpotifyApi::Album.find_many: album not found (id=#{id})")
+          nil
+        end
+      end
+
+      def tracks(id, limit: nil, offset: nil, market: nil)
+        params = {}
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+        params[:market] = market if market.present?
+
+        Page.build(client.get("albums/#{id}/tracks", params))
+      end
+
+      # limit の既定は SpotifyApi.config.search_limit（定数ではなく設定値。
+      # Development Mode では取得件数の上限が下がるため）。
+      # market の既定は SpotifyApi.config.market（'JP'）。
+      def search(query, limit: SpotifyApi.config.search_limit, offset: nil, market: SpotifyApi.config.market)
+        params = { q: query, type: 'album', limit:, market: }
+        params[:offset] = offset if offset
+
+        body = client.get('search', params)
+        Page.build(body['albums'])
+      end
+
+      # テスト間で注入した Client が漏れないよう、teardown で必ず呼ぶこと。
+      def reset_client!
+        @client = nil
+      end
+
+      private
+
+      def client
+        @client ||= Client.new
+      end
+    end
+  end
+end

--- a/lib/spotify_api/audio_features.rb
+++ b/lib/spotify_api/audio_features.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module SpotifyApi
+  class AudioFeatures
+    # audio-features?ids= に一度に渡せる ID 数の上限（Spotify の仕様）。
+    MAX_IDS_PER_REQUEST = 100
+
+    class << self
+      # テストから Client を差し替えるための注入口（SpotifyApi::AudioFeatures.client = fake_client）。
+      attr_writer :client
+
+      # audio-features は Spotify で deprecated 扱いのエンドポイントであるため、
+      # 403 / 404 が返った場合は例外を伝播させず nil を返す。将来エンドポイントが
+      # 完全に廃止されたときに、楽曲取得バッチ全体が落ちないようにするための防御。
+      # それ以外の例外（401 / 429 / 5xx）はレート制限を握りつぶさないよう伝播させる。
+      def find(id)
+        Response.build(client.get("audio-features/#{id}"))
+      rescue ForbiddenError, NotFoundError => e
+        Rails.logger.warn("SpotifyApi::AudioFeatures.find: unavailable (#{e.class}, id=#{id})")
+        nil
+      end
+
+      # ids は Spotify の上限（100件）に合わせて分割し、複数回リクエストする。
+      # レスポンスの audio_features 配列には該当なしのトラックが null として
+      # 混ざるため、結果から除外する。
+      def find_many(ids)
+        ids.each_slice(MAX_IDS_PER_REQUEST).flat_map { |batch| fetch_batch(batch) }
+      end
+
+      # テスト間で注入した Client が漏れないよう、teardown で必ず呼ぶこと。
+      def reset_client!
+        @client = nil
+      end
+
+      private
+
+      def fetch_batch(ids)
+        body = client.get('audio-features', { ids: ids.join(',') })
+        Response.build(body['audio_features']).compact
+      rescue ForbiddenError, NotFoundError => e
+        Rails.logger.warn("SpotifyApi::AudioFeatures.find_many: unavailable (#{e.class})")
+        []
+      end
+
+      def client
+        @client ||= Client.new
+      end
+    end
+  end
+end

--- a/lib/spotify_api/client.rb
+++ b/lib/spotify_api/client.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'faraday/net_http'
+
+module SpotifyApi
+  class Client
+    # connection はテストで Faraday テストアダプタを差し込むための注入口。
+    def initialize(config = SpotifyApi.config, connection: nil)
+      @config = config
+      @connection = connection
+    end
+
+    # access_token を渡すと、既定のアプリトークン（Client Credentials）ではなく
+    # そのトークンを使う。ユーザー単位の操作（プレイリスト編集など）で使用する。
+    #
+    # access_token がキーワード引数のため、params / body は必ず Hash リテラルとして
+    # 波かっこ付きで渡すこと（get('search', { q: 'touhou' })）。
+    # 波かっこを省くとキーワード引数として解釈される。
+    def get(path, params = {}, access_token: nil)
+      response = connection.get(path, params) { |req| apply_access_token(req, access_token) }
+      handle_response(response)
+    end
+
+    def post(path, body = {}, access_token: nil)
+      response = connection.post(path, body) { |req| apply_access_token(req, access_token) }
+      handle_response(response)
+    end
+
+    def put(path, body = {}, access_token: nil)
+      response = connection.put(path, body) { |req| apply_access_token(req, access_token) }
+      handle_response(response)
+    end
+
+    # Spotify のプレイリスト項目削除は body を伴うため、DELETE でも body を受け取れるようにする。
+    def delete(path, body = nil, access_token: nil)
+      response = connection.delete(path) do |req|
+        req.body = body unless body.nil?
+        apply_access_token(req, access_token)
+      end
+      handle_response(response)
+    end
+
+    private
+
+    attr_reader :config
+
+    def connection
+      @connection ||= ExternalApi::Connection.build(:spotify, url: Config::API_URL, adapter: config.adapter) do |conn|
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
+        # Proc を渡すとリクエストごとに評価されるため、トークンの期限切れ後も
+        # 更新されたトークンが使われる（コネクション生成時の値に固定されない）。
+        conn.request :authorization, 'Bearer', -> { config.access_token }
+      end
+    end
+
+    # Faraday の authorization ミドルウェアは既に Authorization ヘッダがある場合は何もしないため、
+    # ここで設定した値がアプリトークンより優先される。
+    def apply_access_token(request, access_token)
+      request.headers['Authorization'] = "Bearer #{access_token}" if access_token.present?
+    end
+
+    # 取得済みのレスポンスをそのまま返すだけで、追加の HTTP リクエストは一切行わない。
+    #
+    # RSpotify::Base#method_missing は未取得の属性にアクセスされると裏で API を叩き直す。
+    # この暗黙のリクエストが Development Mode のクォータ枯渇の主因になっているため、
+    # SpotifyApi では同様の仕組みを絶対に実装しない。
+    def handle_response(response)
+      status = response.status
+      return response.body if status.between?(200, 299)
+
+      body = response.body.is_a?(Hash) ? response.body : {}
+      message = body.dig('error', 'message') || "Spotify API request failed with status #{status}"
+
+      raise error_class(status, body).new(message, status:, response:, retry_after: retry_after(response))
+    end
+
+    def error_class(status, body)
+      case status
+      when 401 then AuthenticationError
+      when 403 then ForbiddenError
+      when 404 then NotFoundError
+      when 429 then quota_exceeded?(body) ? QuotaExceededError : RateLimitError
+      when 500..599 then ServerError
+      else ApiError
+      end
+    end
+
+    # Development Mode のクォータ超過は 429 かつ reason が QUOTA_EXCEEDED で返る。
+    def quota_exceeded?(body)
+      body.dig('error', 'reason') == 'QUOTA_EXCEEDED'
+    end
+
+    def retry_after(response)
+      response.headers['retry-after']&.to_i
+    end
+  end
+end

--- a/lib/spotify_api/config.rb
+++ b/lib/spotify_api/config.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module SpotifyApi
+  class Config
+    ACCOUNTS_URL = 'https://accounts.spotify.com'
+    API_URL = 'https://api.spotify.com/v1/'
+    DEFAULT_TOKEN_TTL = 3600      # Spotify の既定。expires_in が無い場合のフォールバック
+    REFRESH_MARGIN = 60.seconds   # 期限切れ前に再取得を始めるマージン
+
+    # フィーチャーフラグの ENV を true とみなす値（大文字小文字は問わない）。
+    TRUTHY_VALUES = %w[1 true yes on].freeze
+
+    attr_accessor :client_id, :client_secret, :market, :search_limit, :adapter, :native_client_enabled, :playlist_items_path
+    attr_writer :token_connection
+
+    def initialize
+      @client_id = ENV.fetch('SPOTIFY_CLIENT_ID', nil)
+      @client_secret = ENV.fetch('SPOTIFY_CLIENT_SECRET', nil)
+      @market = 'JP'
+      # Development Mode では検索の取得件数上限が下がるため、定数ではなく設定値にする。
+      @search_limit = ENV.fetch('SPOTIFY_SEARCH_LIMIT', 50).to_i
+      @adapter = :net_http
+      @native_client_enabled = truthy?(ENV.fetch('SPOTIFY_NATIVE_CLIENT', nil))
+      # 2026年2月に /playlists/{id}/tracks → /playlists/{id}/items へのリネームが
+      # 告知されたが、2026年3月9日に既存インテグレーション向けの適用は延期された。
+      # 動作実績があるのは /tracks のため、既定はそちらにする（詳細は Playlist 参照）。
+      @playlist_items_path = ENV.fetch('SPOTIFY_PLAYLIST_ITEMS_PATH', 'tracks')
+      # SpotifyApi.config は単一インスタンスを共有するため、キャッシュの
+      # 判定と再取得をまとめて排他制御する。
+      @token_mutex = Mutex.new
+    end
+
+    # Client Credentials フローで取得したアクセストークン。有効期限まで再利用する。
+    #
+    # トークン取得は起動時ではなく最初の API 呼び出し時に行う（遅延取得）。
+    # config/initializers/rspotify.rb は after_initialize で先に認証しているが、
+    # その方式でも Spotify 側の障害時には起動が重くなるため、SpotifyApi では
+    # 初期化時にネットワークI/Oを一切走らせない方針をとる。
+    def access_token
+      @token_mutex.synchronize do
+        fetch_access_token if token_refresh_required?
+        @access_token
+      end
+    end
+
+    # キャッシュ済みトークンを破棄し、次回アクセス時に再取得させる。
+    def reset_token!
+      @token_mutex.synchronize do
+        @access_token = nil
+        @token_expires_at = nil
+      end
+    end
+
+    # トークン取得専用のコネクション。
+    #
+    # Bearer 認証ミドルウェアを付けてはいけない。トークンを取得するための
+    # リクエストがトークンを要求する鶏卵問題になるため。
+    def token_connection
+      @token_connection ||= ExternalApi::Connection.build(:spotify_accounts, url: ACCOUNTS_URL, adapter:) do |conn|
+        conn.response :json, content_type: /\bjson$/
+      end
+    end
+
+    private
+
+    def token_refresh_required?
+      @access_token.nil? || Time.current >= @token_expires_at - REFRESH_MARGIN
+    end
+
+    def fetch_access_token
+      raise ConfigurationError, 'client_id and client_secret must be provided' if client_id.blank? || client_secret.blank?
+
+      response = request_access_token
+      raise AuthenticationError.new("Failed to fetch Spotify access token with status #{response.status}", status: response.status, response:) unless response.status == 200
+
+      body = response.body || {}
+      @access_token = body['access_token']
+      @token_expires_at = Time.current + (body['expires_in'] || DEFAULT_TOKEN_TTL).to_i
+    end
+
+    def request_access_token
+      token_connection.post('/api/token') do |req|
+        req.headers['Authorization'] = "Basic #{Base64.strict_encode64("#{client_id}:#{client_secret}")}"
+        req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        req.body = URI.encode_www_form(grant_type: 'client_credentials')
+      end
+    end
+
+    def truthy?(value)
+      TRUTHY_VALUES.include?(value.to_s.strip.downcase)
+    end
+  end
+end

--- a/lib/spotify_api/errors.rb
+++ b/lib/spotify_api/errors.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module SpotifyApi
+  # Zeitwerk は errors.rb が SpotifyApi::Errors を定義していることを期待するため、
+  # 名前空間として空のモジュールを置いておく。例外クラス自体は呼び出し側で
+  # SpotifyApi::NotFoundError のように短く書けるよう SpotifyApi 直下に定義する。
+  module Errors; end
+
+  class Error < StandardError; end
+
+  # クライアントID/シークレット未設定など、設定不備によるエラー。
+  class ConfigurationError < Error; end
+
+  # HTTP レスポンスを伴うエラーの基底。status / response / retry_after を保持する。
+  class ApiError < Error
+    attr_reader :status, :response, :retry_after
+
+    def initialize(message, status: nil, response: nil, retry_after: nil)
+      super(message)
+      @status = status
+      @response = response
+      @retry_after = retry_after
+    end
+  end
+
+  # 401
+  class AuthenticationError < ApiError; end
+
+  # 403
+  class ForbiddenError < ApiError; end
+
+  # 404
+  class NotFoundError < ApiError; end
+
+  # 429
+  class RateLimitError < ApiError; end
+
+  # 429 かつ reason == "QUOTA_EXCEEDED"。
+  #
+  # 2026年7月の変更で、Development Mode のクォータ超過は
+  # {"error":{"status":429,"reason":"QUOTA_EXCEEDED"}} として返るようになった。
+  # 通常のレート制限と違い短時間では回復しない（Retry-After が数時間規模になる）ため、
+  # 呼び出し側でリトライせず打ち切るなど別扱いにできるよう独立した例外にする。
+  # RateLimitError を継承しているので、区別が不要な箇所では従来どおり
+  # RateLimitError で rescue できる。
+  class QuotaExceededError < RateLimitError; end
+
+  # 5xx
+  class ServerError < ApiError; end
+end

--- a/lib/spotify_api/page.rb
+++ b/lib/spotify_api/page.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module SpotifyApi
+  # Spotify のページングオブジェクト（paging object）を表す小さなクラス。
+  #
+  # { "items" => [...], "total" => n, "limit" => l, "offset" => o, "next" => url } という
+  # 形の Hash を受け取る。Response はネストした値を生の Hash / Array のまま保持する
+  # 設計のため、response.items のようにアクセスすると Hash の配列のままでメソッド
+  # アクセスができない。ページングを扱うリソースメソッド（Album.tracks / Album.search
+  # など）では items を Response.build で包んだ上で total / limit / offset をまとめて
+  # 返す必要があるため、このクラスを用意する。
+  class Page
+    include Enumerable
+
+    attr_reader :items, :total, :limit, :offset, :next_url, :body
+
+    delegate :size, :empty?, to: :items
+
+    class << self
+      # body は paging object の Hash。nil や items 欠落にも耐える。
+      def build(body)
+        new(body || {})
+      end
+    end
+
+    def initialize(body)
+      @body = body
+      @items = Response.build(body['items'] || [])
+      @total = body['total']
+      @limit = body['limit']
+      @offset = body['offset']
+      @next_url = body['next']
+    end
+
+    def each(&)
+      items.each(&)
+    end
+
+    # Spotify は最終ページで next が null になるため、それを最終ページの判定に使う。
+    # items.size < limit による判定は limit 省略時に誤判定するため使わない。
+    def last_page?
+      next_url.blank?
+    end
+  end
+end

--- a/lib/spotify_api/playlist.rb
+++ b/lib/spotify_api/playlist.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+module SpotifyApi
+  # パスに先頭スラッシュを付けないこと（lib/spotify_api/album.rb 参照）。
+  #
+  # すべてのメソッドが UserSession のアクセストークンを使う。SpotifyApi::Config が
+  # 管理するアプリトークン（Client Credentials）ではプレイリストの読み書きはできない。
+  class Playlist
+    # 自動ページング（all_items / all_mine）が辿るページ数の安全弁。
+    # Spotify 側の不具合等で next が終わらず返り続けた場合に、無限ループで
+    # プロセスがハングし続けるのを防ぐための保険。実運用でここに到達することは
+    # 想定していない（MAX_PAGES × limit で数万〜数十万件相当）。
+    MAX_PAGES = 1000
+
+    class << self
+      # テストから Client を差し替えるための注入口（SpotifyApi::Playlist.client = fake_client）。
+      attr_writer :client
+
+      def find(session, id)
+        Response.build(client.get("playlists/#{id}", {}, access_token: session.access_token))
+      end
+
+      def items(session, id, limit: nil, offset: nil)
+        params = {}
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+
+        Page.build(with_items_path_fallback(id) { |path| client.get(path, params, access_token: session.access_token) })
+      end
+
+      def all_items(session, id, limit: 100)
+        fetch_all(limit:) { |offset| items(session, id, limit:, offset:) }
+      end
+
+      def mine(session, limit: nil, offset: nil)
+        params = {}
+        params[:limit] = limit if limit
+        params[:offset] = offset if offset
+
+        Page.build(client.get('me/playlists', params, access_token: session.access_token))
+      end
+
+      def all_mine(session, limit: 50)
+        fetch_all(limit:) { |offset| mine(session, limit:, offset:) }
+      end
+
+      def create(session, name:, public: true, description: nil)
+        body = { name:, public: }
+        body[:description] = description if description.present?
+
+        Response.build(request_create(session, body))
+      end
+
+      def add_items(session, id, uris)
+        Response.build(with_items_path_fallback(id) { |path| client.post(path, { uris: }, access_token: session.access_token) })
+      end
+
+      def remove_items(session, id, uris)
+        body = { tracks: uris.map { |uri| { uri: } } }
+        Response.build(with_items_path_fallback(id) { |path| client.delete(path, body, access_token: session.access_token) })
+      end
+
+      def replace_items(session, id, uris)
+        Response.build(with_items_path_fallback(id) { |path| client.put(path, { uris: }, access_token: session.access_token) })
+      end
+
+      # items_path / create のパス記憶をリセットする。テストの teardown 用。
+      def reset_items_path!
+        @items_path = nil
+        @create_path_style = nil
+      end
+
+      # テスト間で注入した Client が漏れないよう、teardown で必ず呼ぶこと。
+      def reset_client!
+        @client = nil
+      end
+
+      private
+
+      def client
+        @client ||= Client.new
+      end
+
+      # items_path（tracks / items）を解決してリクエストを実行する共通処理。
+      #
+      # 2026年2月に /playlists/{id}/tracks → /playlists/{id}/items へのリネームが
+      # 告知されたが、2026年3月9日に既存インテグレーション向けの適用は延期された。
+      # 2026-07時点でどちらが有効かは未検証（Spotify のクォータ枯渇のため実APIで
+      # 確認できていない）。既定は動作実績のある 'tracks'
+      # （SpotifyApi.config.playlist_items_path、ENV で /items に切替可）とし、
+      # 既定パスが NotFoundError を返した場合に限り、もう一方のパスへ1回だけ
+      # フォールバックする。成功したパスはプロセス内に記憶し、以降はそちらを使う。
+      #
+      # フォールバックするのは NotFoundError のときだけ。429 / 401 / 5xx で
+      # フォールバックすると、レート制限中に同じリクエストを2倍撃つことになるため、
+      # それ以外の例外はそのまま伝播させる。
+      def with_items_path_fallback(id)
+        path = items_path
+        yield(build_items_path(id, path))
+      rescue NotFoundError
+        alternate = alternate_items_path(path)
+        Rails.logger.warn("SpotifyApi::Playlist: '#{path}' returned 404, falling back to '#{alternate}'")
+        result = yield(build_items_path(id, alternate))
+        @items_path = alternate
+        result
+      end
+
+      def items_path
+        @items_path ||= SpotifyApi.config.playlist_items_path
+      end
+
+      def alternate_items_path(path)
+        path == 'tracks' ? 'items' : 'tracks'
+      end
+
+      def build_items_path(id, path)
+        "playlists/#{id}/#{path}"
+      end
+
+      # POST /users/{user_id}/playlists は廃止告知済みで、後継は POST /me/playlists。
+      # 既定は me/playlists とし、NotFoundError のときだけ廃止予定のパスへ1回だけ
+      # フォールバックする（未移行の環境向けの保険）。以降どちらを使うかはスタイル
+      # （:me / :user）だけを記憶し、パス自体は毎回 session から組み立てる
+      # （ユーザーIDまで記憶すると、次に別ユーザーのセッションで呼ばれたときに
+      # 誤ったユーザーIDのパスを使ってしまうため）。
+      def request_create(session, body)
+        path = create_path_for(session)
+        client.post(path, body, access_token: session.access_token)
+      rescue NotFoundError
+        raise if create_path_style == :user
+
+        alternate = "users/#{session.spotify_user_id}/playlists"
+        Rails.logger.warn("SpotifyApi::Playlist: '#{path}' returned 404, falling back to '#{alternate}'")
+        result = client.post(alternate, body, access_token: session.access_token)
+        @create_path_style = :user
+        result
+      end
+
+      def create_path_for(session)
+        create_path_style == :user ? "users/#{session.spotify_user_id}/playlists" : 'me/playlists'
+      end
+
+      def create_path_style
+        @create_path_style ||= :me
+      end
+
+      # ページングを最終ページまで自動で辿り、Response の配列として返す。
+      #
+      # Page#last_page? を基本の終了条件としつつ、取得済み件数が total に達したら
+      # 止める。ページを取得しても items が空だった場合も止める（total が信頼できない
+      # レスポンスへの保険）。MAX_PAGES は上記に加えた安全弁（クラスコメント参照）。
+      def fetch_all(limit:)
+        results = []
+        offset = 0
+        page_count = 0
+
+        loop do
+          page_count += 1
+          if page_count > MAX_PAGES
+            Rails.logger.error("SpotifyApi::Playlist: aborted pagination after #{MAX_PAGES} pages (safety valve)")
+            break
+          end
+
+          page = yield(offset)
+          results.concat(page.items)
+
+          break if page.items.empty?
+          break if page.last_page?
+          break if page.total && results.size >= page.total
+
+          offset += limit
+        end
+
+        results
+      end
+    end
+  end
+end

--- a/lib/spotify_api/response.rb
+++ b/lib/spotify_api/response.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module SpotifyApi
+  # Spotify の JSON レスポンスを、メソッドアクセスできるオブジェクトに包む。
+  #
+  # Apple Music と違い Spotify の JSON はフラット（attributes ラッパーが無い）ため、
+  # トップレベルのキーをそのまま公開するだけでよい。
+  # ネストした値は生の Hash / Array のまま保持するので、
+  # album.external_ids['upc'] や album.external_urls['spotify'] のような
+  # 既存の書き方がそのまま動く。
+  class Response
+    class << self
+      # Hash はこのクラスで包み、Array は各要素を包んだ配列にし、
+      # それ以外（nil やスカラー）はそのまま返す。
+      def build(value)
+        case value
+        when Hash then new(value)
+        when Array then value.map { |element| build(element) }
+        else value
+        end
+      end
+    end
+
+    attr_reader :data
+
+    def initialize(data)
+      @data = data
+    end
+
+    # キー名でのアクセス。文字列・シンボルのどちらでも引ける。
+    def [](key)
+      data[key.to_s]
+    end
+
+    def key?(key)
+      data.key?(key.to_s)
+    end
+
+    def to_h
+      data
+    end
+
+    # DB の payload カラムにそのまま保存されるため、生の Hash を返す。
+    # ここで整形すると保存済みデータとの互換性が崩れる。
+    def as_json(_options = {})
+      data
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      key?(name) || super
+    end
+
+    # 未定義のキーは nil を返すだけ。
+    #
+    # RSpotify::Base#method_missing は未取得の属性にアクセスされると裏で API を
+    # 叩き直す。この暗黙のリクエストが Development Mode のクォータ枯渇の主因のため、
+    # 同様の仕組みは絶対に実装しない。
+    def method_missing(name, *args)
+      return super unless args.empty?
+
+      data[name.to_s]
+    end
+  end
+end

--- a/lib/spotify_api/track.rb
+++ b/lib/spotify_api/track.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SpotifyApi
+  class Track
+    class << self
+      # テストから Client を差し替えるための注入口（SpotifyApi::Track.client = fake_client）。
+      attr_writer :client
+
+      def find(id, market: nil)
+        params = {}
+        params[:market] = market if market.present?
+
+        Response.build(client.get("tracks/#{id}", params))
+      end
+
+      # Album.find_many と同じ方針。GET /tracks?ids= のバルク取得エンドポイントは
+      # 使わず1件ずつ逐次取得する。404 は例外にせず結果から除外して warn ログを出し、
+      # それ以外の例外（429 など）はそのまま伝播させる（レート制限を握りつぶさない）。
+      def find_many(ids, market: nil)
+        ids.filter_map do |id|
+          find(id, market:)
+        rescue NotFoundError
+          Rails.logger.warn("SpotifyApi::Track.find_many: track not found (id=#{id})")
+          nil
+        end
+      end
+
+      # テスト間で注入した Client が漏れないよう、teardown で必ず呼ぶこと。
+      def reset_client!
+        @client = nil
+      end
+
+      private
+
+      def client
+        @client ||= Client.new
+      end
+    end
+  end
+end

--- a/lib/spotify_api/user_session.rb
+++ b/lib/spotify_api/user_session.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module SpotifyApi
+  # ユーザー単位の Authorization Code トークン（プレイリスト編集など、ユーザー本人の
+  # 権限が必要な操作）を扱う。Client Credentials フローで取得するアプリトークンを
+  # 扱う SpotifyApi::Config とは別物。
+  #
+  # app/controllers/sessions_controller.rb が OmniAuth の auth_hash を
+  # redis.set(user.id, auth_hash.to_json) で保存しているため、find はその値を
+  # 読み込んで UserSession を組み立てる。auth_hash は JSON 経由なのでキーは
+  # 文字列である点に注意（credentials['token'] のようにアクセスする）。
+  class UserSession
+    REFRESH_MARGIN = 60.seconds # 期限切れ前に再取得を始めるマージン（SpotifyApi::Config と同じ考え方）
+
+    class << self
+      # Redis から auth_hash を読み込んで UserSession を組み立てる。該当キーが無ければ nil を返す。
+      #
+      # rspotify の RSpotify::User は該当ユーザーの認証情報が見つからないと
+      # 「最初に登録されたユーザーのトークン」にフォールバックする（rspotify/user.rb:66）。
+      # マルチユーザー環境では別人のアカウントにプレイリストを書き込む事故につながるため、
+      # SpotifyApi ではこの挙動を絶対に引き継がない。見つからなければ黙って nil を返すだけにする。
+      def find(user_id, config: SpotifyApi.config)
+        json = RedisPool.with { |redis| redis.get(user_id) }
+        return nil if json.blank?
+
+        new(JSON.parse(json), user_id:, config:)
+      end
+    end
+
+    attr_reader :auth_hash
+
+    # user_id を渡すと、リフレッシュ成功時に Redis への書き戻しを行う（.find 経由の想定）。
+    # config はテストから Client と同じ流儀（DI）で差し替えるための注入口。
+    def initialize(auth_hash, user_id: nil, config: SpotifyApi.config)
+      @auth_hash = auth_hash
+      @user_id = user_id
+      @config = config
+      # access_token の期限チェック〜リフレッシュ〜Redis書き戻しを排他制御する。
+      # 複数スレッドから同時に呼ばれても二重にリフレッシュしないようにするため。
+      @mutex = Mutex.new
+    end
+
+    def spotify_user_id
+      auth_hash['uid']
+    end
+
+    def refresh_token
+      credentials['refresh_token']
+    end
+
+    def expires_at
+      Time.zone.at(credentials['expires_at'].to_i)
+    end
+
+    def expired?
+      expires_at - REFRESH_MARGIN <= Time.current
+    end
+
+    # 有効なアクセストークンを返す。期限切れ間近なら事前にリフレッシュしてから返す。
+    #
+    # rspotify は 401 が返ってきてからエラーメッセージの文字列マッチでリフレッシュしており
+    # （RSpotify::Base#method_missing 経由）、そのぶん毎回1往復を無駄にしている。
+    # ここでは期限を先読みしてリフレッシュすることで、その無駄な往復を無くす。
+    def access_token
+      @mutex.synchronize do
+        perform_refresh! if expired?
+        credentials['token']
+      end
+    end
+
+    # 期限に関わらず強制的にリフレッシュする。
+    def refresh!
+      @mutex.synchronize { perform_refresh! }
+      credentials['token']
+    end
+
+    private
+
+    attr_reader :user_id, :config
+
+    def credentials
+      auth_hash['credentials'] ||= {}
+    end
+
+    def perform_refresh!
+      raise AuthenticationError, 'refresh_token is missing; cannot refresh Spotify access token' if refresh_token.blank?
+
+      response = request_token_refresh
+      raise AuthenticationError.new("Failed to refresh Spotify access token with status #{response.status}", status: response.status, response:) unless response.status == 200
+
+      apply_refreshed_credentials(response.body || {})
+      persist!
+    end
+
+    def apply_refreshed_credentials(body)
+      credentials['token'] = body['access_token']
+      credentials['expires_at'] = (Time.current + (body['expires_in'] || Config::DEFAULT_TOKEN_TTL).to_i).to_i
+      credentials['expires'] = true
+      # レスポンスに refresh_token が含まれないことがある（Spotify の仕様）。
+      # ここで上書きして nil にすると以後リフレッシュ不能になるため、含まれている
+      # 場合だけ更新し、含まれていなければ既存の refresh_token を維持する。
+      credentials['refresh_token'] = body['refresh_token'] if body['refresh_token'].present?
+    end
+
+    def request_token_refresh
+      config.token_connection.post('/api/token') do |req|
+        req.headers['Authorization'] = "Basic #{Base64.strict_encode64("#{config.client_id}:#{config.client_secret}")}"
+        req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        req.body = URI.encode_www_form(grant_type: 'refresh_token', refresh_token:)
+      end
+    end
+
+    # user_id が分かっている場合（.find 経由で生成されたとき）だけ Redis に書き戻す。
+    # 書き戻しに失敗しても例外は伝播させない。ここで落とすとプレイリスト更新処理
+    # 全体が失敗してしまうため、取得済みのトークンはそのまま使わせ、warn ログのみ残す。
+    def persist!
+      return if user_id.blank?
+
+      RedisPool.with { |redis| redis.set(user_id, auth_hash.to_json) }
+    rescue StandardError => e
+      Rails.logger.warn("SpotifyApi::UserSession#persist!: failed to write back to Redis (#{e.class}: #{e.message})")
+    end
+  end
+end

--- a/test/lib/external_api/connection_test.rb
+++ b/test/lib/external_api/connection_test.rb
@@ -8,7 +8,9 @@ module ExternalApi
       yt_music: { open_timeout: 5, timeout: 15 },
       line_music: { open_timeout: 5, timeout: 10 },
       apple_music: { open_timeout: 5, timeout: 15 },
-      github: { open_timeout: 5, timeout: 30 }
+      github: { open_timeout: 5, timeout: 30 },
+      spotify: { open_timeout: 5, timeout: 15 },
+      spotify_accounts: { open_timeout: 5, timeout: 10 }
     }.freeze
 
     EXPECTED_TIMEOUTS.each do |service, expected|
@@ -51,16 +53,45 @@ module ExternalApi
       assert_match(/unknown_service/, error.message)
     end
 
-    test 'every profile retries on rate limit and server error statuses' do
-      Connection::PROFILES.each_key do |service|
+    # spotify / spotify_accounts は 429 を意図的に除外しているため、この共通アサーションの対象外にする。
+    test 'every profile except spotify and spotify_accounts retries on rate limit and server error statuses' do
+      (Connection::PROFILES.keys - %i[spotify spotify_accounts]).each do |service|
         conn = Connection.build(service, url: 'https://example.com')
-        options = retry_handler(conn).instance_variable_get(:@kwargs)
 
-        assert_equal [429, 500, 502, 503, 504], options[:retry_statuses], "#{service} の retry_statuses が想定と異なります"
+        assert_equal [429, 500, 502, 503, 504], retry_options(conn)[:retry_statuses], "#{service} の retry_statuses が想定と異なります"
       end
     end
 
+    test 'spotify profile excludes 429 from the retry statuses' do
+      conn = Connection.build(:spotify, url: 'https://example.com')
+      retry_statuses = retry_options(conn)[:retry_statuses]
+
+      assert_equal [500, 502, 503, 504], retry_statuses
+      assert_not_includes retry_statuses, 429
+    end
+
+    test 'spotify_accounts profile excludes 429 from the retry statuses and retries post' do
+      conn = Connection.build(:spotify_accounts, url: 'https://example.com')
+      options = retry_options(conn)
+
+      assert_equal [500, 502, 503, 504], options[:retry_statuses]
+      assert_not_includes options[:retry_statuses], 429
+      assert_includes options[:methods], :post
+    end
+
+    test 'profile retry options override the shared retry options' do
+      conn = Connection.build(:spotify, url: 'https://example.com')
+
+      assert_not_equal Connection::SHARED_RETRY_OPTIONS[:retry_statuses], retry_options(conn)[:retry_statuses]
+      # 上書きしていないキーは共通設定がそのまま残る。
+      assert_equal Connection::SHARED_RETRY_OPTIONS[:exceptions], retry_options(conn)[:exceptions]
+    end
+
     private
+
+    def retry_options(conn)
+      retry_handler(conn).instance_variable_get(:@kwargs)
+    end
 
     def retry_handler(conn)
       conn.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }

--- a/test/lib/spotify_api/album_test.rb
+++ b/test/lib/spotify_api/album_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class AlbumTest < ActiveSupport::TestCase
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+    FakeConfig = Struct.new(:access_token, :adapter)
+
+    setup do
+      @stubs = Faraday::Adapter::Test::Stubs.new
+      Album.client = build_client
+    end
+
+    teardown do
+      # 差し込んだ Client がテスト間で漏れないよう、必ずリセットする。
+      Album.reset_client!
+    end
+
+    test 'find does not send a market parameter by default' do
+      query = capture_query('/v1/albums/123', { id: '123', name: 'album' })
+
+      Album.find('123')
+
+      assert_nil query[:value]
+    end
+
+    test 'find sends market only when explicitly given' do
+      query = capture_query('/v1/albums/123', { id: '123' })
+
+      Album.find('123', market: 'JP')
+
+      assert_equal 'market=JP', query[:value]
+    end
+
+    test 'find wraps the response body' do
+      @stubs.get('/v1/albums/123') { [200, JSON_HEADERS, { id: '123', name: 'album' }.to_json] }
+
+      album = Album.find('123')
+
+      assert_instance_of Response, album
+      assert_equal 'album', album.name
+    end
+
+    test 'find_many fetches each id individually instead of using the bulk endpoint' do
+      @stubs.get('/v1/albums/1') { [200, JSON_HEADERS, { id: '1' }.to_json] }
+      @stubs.get('/v1/albums/2') { [200, JSON_HEADERS, { id: '2' }.to_json] }
+
+      albums = Album.find_many(%w[1 2])
+
+      assert_equal %w[1 2], albums.map(&:id)
+    end
+
+    test 'find_many skips ids that respond with 404' do
+      @stubs.get('/v1/albums/1') { [200, JSON_HEADERS, { id: '1' }.to_json] }
+      @stubs.get('/v1/albums/2') { [404, JSON_HEADERS, { error: { status: 404, message: 'not found' } }.to_json] }
+
+      albums = Album.find_many(%w[1 2])
+
+      assert_equal ['1'], albums.map(&:id)
+    end
+
+    test 'find_many propagates errors other than 404, such as rate limiting' do
+      @stubs.get('/v1/albums/1') { [429, JSON_HEADERS, { error: { status: 429, message: 'rate limited' } }.to_json] }
+
+      assert_raises(RateLimitError) { Album.find_many(%w[1]) }
+    end
+
+    test 'tracks builds the path and query parameters' do
+      requested_path = {}
+      query = {}
+      @stubs.get('/v1/albums/123/tracks') do |env|
+        requested_path[:value] = env.url.path
+        query[:value] = env.url.query
+        [200, JSON_HEADERS, { items: [] }.to_json]
+      end
+
+      Album.tracks('123', limit: 50, offset: 50)
+
+      assert_equal '/v1/albums/123/tracks', requested_path[:value]
+      assert_equal 'limit=50&offset=50', query[:value]
+    end
+
+    test 'tracks returns a Page' do
+      @stubs.get('/v1/albums/123/tracks') { [200, JSON_HEADERS, { items: [{ id: 't1' }], total: 1 }.to_json] }
+
+      page = Album.tracks('123')
+
+      assert_instance_of Page, page
+      assert_equal 't1', page.items.first.id
+      assert_equal 1, page.total
+    end
+
+    test 'search sends the configured search_limit and market by default' do
+      query = capture_query('/v1/search', { albums: { items: [] } })
+
+      Album.search('touhou')
+
+      params = URI.decode_www_form(query[:value]).to_h
+
+      assert_equal 'touhou', params['q']
+      assert_equal 'album', params['type']
+      assert_equal SpotifyApi.config.search_limit.to_s, params['limit']
+      assert_equal SpotifyApi.config.market, params['market']
+    end
+
+    test 'search returns a Page built from body["albums"]' do
+      @stubs.get('/v1/search') { [200, JSON_HEADERS, { albums: { items: [{ id: 'a1' }], total: 1 } }.to_json] }
+
+      page = Album.search('touhou')
+
+      assert_instance_of Page, page
+      assert_equal 'a1', page.items.first.id
+    end
+
+    test 'search returns an empty Page when the response has no albums key' do
+      @stubs.get('/v1/search') { [200, JSON_HEADERS, {}.to_json] }
+
+      page = Album.search('touhou')
+
+      assert_instance_of Page, page
+      assert_empty page
+    end
+
+    private
+
+    def build_client
+      connection = Faraday.new(url: Config::API_URL) do |conn|
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
+        conn.adapter :test, @stubs
+      end
+
+      Client.new(FakeConfig.new('TOKEN', :test), connection:)
+    end
+
+    # 指定パスへのリクエストを1回だけ受け付け、クエリ文字列を記録するスタブを登録する。
+    def capture_query(path, body)
+      query = {}
+      @stubs.get(path) do |env|
+        query[:value] = env.url.query
+        [200, JSON_HEADERS, body.to_json]
+      end
+      query
+    end
+  end
+end

--- a/test/lib/spotify_api/audio_features_test.rb
+++ b/test/lib/spotify_api/audio_features_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class AudioFeaturesTest < ActiveSupport::TestCase
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+    FakeConfig = Struct.new(:access_token, :adapter)
+
+    setup do
+      @stubs = Faraday::Adapter::Test::Stubs.new
+      AudioFeatures.client = build_client
+    end
+
+    teardown do
+      # 差し込んだ Client がテスト間で漏れないよう、必ずリセットする。
+      AudioFeatures.reset_client!
+    end
+
+    test 'find wraps the response body' do
+      @stubs.get('/v1/audio-features/1') { [200, JSON_HEADERS, { id: '1', tempo: 120.0 }.to_json] }
+
+      features = AudioFeatures.find('1')
+
+      assert_instance_of Response, features
+      assert_equal 120.0, features.tempo
+    end
+
+    test 'find returns nil and does not raise when the endpoint responds with 403' do
+      @stubs.get('/v1/audio-features/1') { [403, JSON_HEADERS, { error: { status: 403, message: 'forbidden' } }.to_json] }
+
+      assert_nil AudioFeatures.find('1')
+    end
+
+    test 'find returns nil and does not raise when the endpoint responds with 404' do
+      @stubs.get('/v1/audio-features/1') { [404, JSON_HEADERS, { error: { status: 404, message: 'not found' } }.to_json] }
+
+      assert_nil AudioFeatures.find('1')
+    end
+
+    test 'find propagates rate limit errors instead of swallowing them' do
+      @stubs.get('/v1/audio-features/1') { [429, JSON_HEADERS, { error: { status: 429, message: 'rate limited' } }.to_json] }
+
+      assert_raises(RateLimitError) { AudioFeatures.find('1') }
+    end
+
+    test 'find_many splits ids into batches of 100' do
+      ids = (1..150).map { |i| "id#{i}" }
+      queries = []
+      @stubs.get('/v1/audio-features') do |env|
+        queries << env.url.query
+        [200, JSON_HEADERS, { audio_features: [] }.to_json]
+      end
+
+      AudioFeatures.find_many(ids)
+
+      assert_equal 2, queries.size
+      assert_equal ids.first(100), requested_ids(queries[0])
+      assert_equal ids.last(50), requested_ids(queries[1])
+    end
+
+    test 'find_many excludes null entries from the response' do
+      @stubs.get('/v1/audio-features') do
+        [200, JSON_HEADERS, { audio_features: [{ id: '1' }, nil, { id: '2' }] }.to_json]
+      end
+
+      features = AudioFeatures.find_many(%w[1 2])
+
+      assert_equal %w[1 2], features.map(&:id)
+    end
+
+    test 'find_many returns an empty array and does not raise when the endpoint responds with 403' do
+      @stubs.get('/v1/audio-features') { [403, JSON_HEADERS, { error: { status: 403, message: 'forbidden' } }.to_json] }
+
+      assert_equal [], AudioFeatures.find_many(%w[1 2])
+    end
+
+    test 'find_many returns an empty array and does not raise when the endpoint responds with 404' do
+      @stubs.get('/v1/audio-features') { [404, JSON_HEADERS, { error: { status: 404, message: 'not found' } }.to_json] }
+
+      assert_equal [], AudioFeatures.find_many(%w[1 2])
+    end
+
+    test 'find_many propagates rate limit errors instead of swallowing them' do
+      @stubs.get('/v1/audio-features') { [429, JSON_HEADERS, { error: { status: 429, message: 'rate limited' } }.to_json] }
+
+      assert_raises(RateLimitError) { AudioFeatures.find_many(%w[1 2]) }
+    end
+
+    private
+
+    def requested_ids(query)
+      URI.decode_www_form(query).to_h['ids'].split(',')
+    end
+
+    def build_client
+      connection = Faraday.new(url: Config::API_URL) do |conn|
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
+        conn.adapter :test, @stubs
+      end
+
+      Client.new(FakeConfig.new('TOKEN', :test), connection:)
+    end
+  end
+end

--- a/test/lib/spotify_api/client_test.rb
+++ b/test/lib/spotify_api/client_test.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class ClientTest < ActiveSupport::TestCase
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+    # access_token を返すだけの設定オブジェクト。トークン取得の HTTP を挟まずに済む。
+    FakeConfig = Struct.new(:access_token, :adapter)
+
+    ERROR_CASES = {
+      401 => AuthenticationError,
+      403 => ForbiddenError,
+      404 => NotFoundError,
+      429 => RateLimitError,
+      500 => ServerError,
+      503 => ServerError,
+      418 => ApiError
+    }.freeze
+
+    setup do
+      @stubs = Faraday::Adapter::Test::Stubs.new
+      @config = FakeConfig.new('APP_TOKEN', :test)
+    end
+
+    test 'the default connection uses the shared spotify profile' do
+      conn = Client.new(Config.new).send(:connection)
+      handlers = conn.builder.handlers.map(&:klass)
+
+      assert_equal 5, conn.options.open_timeout
+      assert_equal 15, conn.options.timeout
+      assert_includes handlers, Faraday::Retry::Middleware
+      assert_includes handlers, Faraday::Request::Json
+      assert_includes handlers, Faraday::Response::Json
+      assert_includes handlers, Faraday::Request::Authorization
+    end
+
+    ERROR_CASES.each do |status, error_class|
+      test "raises #{error_class} for status #{status}" do
+        stub_get { [status, JSON_HEADERS, { error: { status:, message: 'boom' } }.to_json] }
+
+        error = assert_raises(error_class) { build_client.get('albums/1') }
+
+        assert_instance_of error_class, error
+        assert_equal status, error.status
+        assert_equal 'boom', error.message
+        assert_not_nil error.response
+      end
+    end
+
+    test 'returns the parsed body for a successful response' do
+      stub_get { [200, JSON_HEADERS, { id: '1', name: 'album' }.to_json] }
+
+      assert_equal({ 'id' => '1', 'name' => 'album' }, build_client.get('albums/1'))
+    end
+
+    test 'returns nil for a response without a body' do
+      @stubs.delete('/v1/playlists/1/tracks') { [204, {}, nil] }
+
+      assert_nil build_client.delete('playlists/1/tracks')
+    end
+
+    test 'raises QuotaExceededError when the 429 reason is QUOTA_EXCEEDED' do
+      stub_get do
+        [429, JSON_HEADERS.merge('Retry-After' => '64063'),
+         { error: { status: 429, reason: 'QUOTA_EXCEEDED', message: 'quota exceeded' } }.to_json]
+      end
+
+      # QuotaExceededError は RateLimitError を継承しているため、こちらでも rescue できる。
+      error = assert_raises(RateLimitError) { build_client.get('albums/1') }
+
+      assert_instance_of QuotaExceededError, error
+      assert_equal 64_063, error.retry_after
+    end
+
+    test 'exposes the Retry-After header on a rate limit error' do
+      stub_get { [429, JSON_HEADERS.merge('Retry-After' => '30'), { error: { status: 429, message: 'rate limited' } }.to_json] }
+
+      error = assert_raises(RateLimitError) { build_client.get('albums/1') }
+
+      assert_instance_of RateLimitError, error
+      assert_equal 30, error.retry_after
+    end
+
+    test 'retry_after is nil when the Retry-After header is absent' do
+      stub_get { [429, JSON_HEADERS, { error: { status: 429, message: 'rate limited' } }.to_json] }
+
+      error = assert_raises(RateLimitError) { build_client.get('albums/1') }
+
+      assert_nil error.retry_after
+    end
+
+    test 'falls back to a generic message when the body has no error message' do
+      stub_get { [500, {}, ''] }
+
+      error = assert_raises(ServerError) { build_client.get('albums/1') }
+
+      assert_equal 'Spotify API request failed with status 500', error.message
+    end
+
+    test 'sends the application token as a bearer token' do
+      request_headers = capture_request_headers
+
+      build_client(with_authorization: true).get('albums/1')
+
+      assert_equal 'Bearer APP_TOKEN', request_headers[:value]['Authorization']
+    end
+
+    test 'prefers the explicitly given access token over the application token' do
+      request_headers = capture_request_headers
+
+      build_client(with_authorization: true).get('albums/1', {}, access_token: 'USER_TOKEN')
+
+      assert_equal 'Bearer USER_TOKEN', request_headers[:value]['Authorization']
+    end
+
+    test 'builds query parameters for get' do
+      url = {}
+      @stubs.get('/v1/search') do |env|
+        url[:value] = env.url
+        [200, JSON_HEADERS, '{}']
+      end
+
+      build_client.get('search', { q: 'touhou', type: 'album' })
+
+      assert_equal 'q=touhou&type=album', url[:value].query
+    end
+
+    test 'sends a json body for post' do
+      body = {}
+      @stubs.post('/v1/playlists/1/tracks') do |env|
+        body[:value] = env.body
+        [201, JSON_HEADERS, { snapshot_id: 'abc' }.to_json]
+      end
+
+      result = build_client.post('playlists/1/tracks', { uris: ['spotify:track:1'] })
+
+      assert_equal({ 'uris' => ['spotify:track:1'] }, JSON.parse(body[:value]))
+      assert_equal({ 'snapshot_id' => 'abc' }, result)
+    end
+
+    test 'sends a json body for put' do
+      body = {}
+      @stubs.put('/v1/playlists/1') do |env|
+        body[:value] = env.body
+        [200, JSON_HEADERS, '{}']
+      end
+
+      build_client.put('playlists/1', { name: 'renamed' })
+
+      assert_equal({ 'name' => 'renamed' }, JSON.parse(body[:value]))
+    end
+
+    test 'sends a json body for delete' do
+      body = {}
+      @stubs.delete('/v1/playlists/1/tracks') do |env|
+        body[:value] = env.body
+        [200, JSON_HEADERS, { snapshot_id: 'abc' }.to_json]
+      end
+
+      build_client.delete('playlists/1/tracks', { tracks: [{ uri: 'spotify:track:1' }] })
+
+      assert_equal({ 'tracks' => [{ 'uri' => 'spotify:track:1' }] }, JSON.parse(body[:value]))
+    end
+
+    private
+
+    # 例外マッピングの検証には retry ミドルウェアの無い素の Faraday を使う。
+    # 既定のコネクションでは 5xx のたびにリトライ待機が入りテストが遅くなるため。
+    def build_client(with_authorization: false)
+      config = @config
+      connection = Faraday.new(url: Config::API_URL) do |conn|
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
+        conn.request(:authorization, 'Bearer', -> { config.access_token }) if with_authorization
+        conn.adapter :test, @stubs
+      end
+
+      Client.new(config, connection:)
+    end
+
+    def stub_get(&)
+      @stubs.get('/v1/albums/1', &)
+    end
+
+    def capture_request_headers
+      headers = {}
+      stub_get do |env|
+        headers[:value] = env.request_headers.dup
+        [200, JSON_HEADERS, '{}']
+      end
+      headers
+    end
+  end
+end

--- a/test/lib/spotify_api/config_test.rb
+++ b/test/lib/spotify_api/config_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class ConfigTest < ActiveSupport::TestCase
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+
+    setup do
+      @stubs = Faraday::Adapter::Test::Stubs.new
+      @config = Config.new
+      @config.client_id = 'CLIENT_ID'
+      @config.client_secret = 'CLIENT_SECRET'
+      @config.token_connection = Faraday.new do |conn|
+        conn.response :json, content_type: /\bjson$/
+        conn.adapter :test, @stubs
+      end
+    end
+
+    test 'reuses the cached token while it is still valid' do
+      calls = stub_token('TOKEN', expires_in: 3600)
+
+      token = @config.access_token
+
+      assert_equal 'TOKEN', token
+      assert_equal token, @config.access_token
+
+      travel_to 3600.seconds.from_now - Config::REFRESH_MARGIN - 1.minute do
+        assert_equal token, @config.access_token
+      end
+
+      assert_equal 1, calls.value
+    end
+
+    test 'refetches the token once the refresh margin is reached' do
+      calls = stub_token(%w[FIRST SECOND], expires_in: 3600)
+
+      assert_equal 'FIRST', @config.access_token
+
+      travel_to 3600.seconds.from_now - Config::REFRESH_MARGIN + 1.minute do
+        assert_equal 'SECOND', @config.access_token
+      end
+
+      assert_equal 2, calls.value
+    end
+
+    test 'falls back to DEFAULT_TOKEN_TTL when the response has no expires_in' do
+      calls = stub_token(%w[FIRST SECOND], expires_in: nil)
+
+      assert_equal 'FIRST', @config.access_token
+
+      travel_to Config::DEFAULT_TOKEN_TTL.seconds.from_now - Config::REFRESH_MARGIN - 1.minute do
+        assert_equal 'FIRST', @config.access_token
+      end
+
+      travel_to Config::DEFAULT_TOKEN_TTL.seconds.from_now - Config::REFRESH_MARGIN + 1.minute do
+        assert_equal 'SECOND', @config.access_token
+      end
+
+      assert_equal 2, calls.value
+    end
+
+    test 'reset_token! discards the cached token' do
+      calls = stub_token(%w[FIRST SECOND], expires_in: 3600)
+
+      assert_equal 'FIRST', @config.access_token
+
+      @config.reset_token!
+
+      assert_equal 'SECOND', @config.access_token
+      assert_equal 2, calls.value
+    end
+
+    test 'raises ConfigurationError when the credentials are blank' do
+      @config.client_id = nil
+
+      assert_raises(ConfigurationError) { @config.access_token }
+
+      @config.client_id = 'CLIENT_ID'
+      @config.client_secret = ''
+
+      assert_raises(ConfigurationError) { @config.access_token }
+    end
+
+    test 'raises AuthenticationError when the token endpoint fails' do
+      @stubs.post('/api/token') { [401, JSON_HEADERS, { error: 'invalid_client' }.to_json] }
+
+      error = assert_raises(AuthenticationError) { @config.access_token }
+
+      assert_equal 401, error.status
+      assert_not_nil error.response
+    end
+
+    test 'sends basic authentication and the client credentials grant' do
+      request_headers = nil
+      request_body = nil
+      @stubs.post('/api/token') do |env|
+        # env はレスポンス処理で書き換えられるため、リクエスト内容はこの時点で控える。
+        request_headers = env.request_headers.dup
+        request_body = env.body
+        [200, JSON_HEADERS, { access_token: 'TOKEN', expires_in: 3600 }.to_json]
+      end
+
+      @config.access_token
+
+      assert_equal "Basic #{Base64.strict_encode64('CLIENT_ID:CLIENT_SECRET')}", request_headers['Authorization']
+      assert_equal 'application/x-www-form-urlencoded', request_headers['Content-Type']
+      assert_equal 'grant_type=client_credentials', request_body
+    end
+
+    test 'fetches the token only once when called from multiple threads' do
+      calls = stub_token('TOKEN', expires_in: 3600, delay: 0.05)
+
+      tokens = Array.new(5) { Thread.new { @config.access_token } }.map(&:value)
+
+      assert_equal ['TOKEN'] * 5, tokens
+      assert_equal 1, calls.value
+    end
+
+    test 'native_client_enabled is true only for truthy environment values' do
+      %w[1 true TRUE yes On].each do |value|
+        with_native_client_env(value) do
+          assert Config.new.native_client_enabled, "#{value.inspect} は true として扱われるべきです"
+        end
+      end
+    end
+
+    test 'native_client_enabled defaults to false' do
+      [nil, 'false', '', '0', 'no'].each do |value|
+        with_native_client_env(value) do
+          assert_not Config.new.native_client_enabled, "#{value.inspect} は false として扱われるべきです"
+        end
+      end
+    end
+
+    private
+
+    # トークンエンドポイントをスタブし、呼び出し回数を数えるカウンタを返す。
+    # tokens に配列を渡すと、呼び出しごとに先頭から順に返す。
+    def stub_token(tokens, expires_in:, delay: nil)
+      queue = Array(tokens)
+      calls = Concurrent::AtomicFixnum.new(0)
+
+      @stubs.post('/api/token') do
+        calls.increment
+        sleep delay if delay
+        body = { access_token: queue.length > 1 ? queue.shift : queue.first }
+        body[:expires_in] = expires_in if expires_in
+        [200, JSON_HEADERS, body.to_json]
+      end
+
+      calls
+    end
+
+    def with_native_client_env(value)
+      original = ENV.fetch('SPOTIFY_NATIVE_CLIENT', nil)
+      ENV['SPOTIFY_NATIVE_CLIENT'] = value
+      yield
+    ensure
+      ENV['SPOTIFY_NATIVE_CLIENT'] = original
+    end
+  end
+end

--- a/test/lib/spotify_api/page_test.rb
+++ b/test/lib/spotify_api/page_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class PageTest < ActiveSupport::TestCase
+    ITEM = { 'id' => '1', 'name' => 'track' }.freeze
+
+    PAGING_BODY = {
+      'items' => [ITEM],
+      'total' => 42,
+      'limit' => 20,
+      'offset' => 0,
+      'next' => 'https://api.spotify.com/v1/albums/1/tracks?offset=20&limit=20'
+    }.freeze
+
+    test 'wraps items with Response and exposes total / limit / offset' do
+      page = Page.build(PAGING_BODY)
+
+      assert_instance_of Response, page.items.first
+      assert_equal '1', page.items.first.id
+      assert_equal 42, page.total
+      assert_equal 20, page.limit
+      assert_equal 0, page.offset
+    end
+
+    test 'keeps the raw body for debugging and payload use cases' do
+      page = Page.build(PAGING_BODY)
+
+      assert_same PAGING_BODY, page.body
+    end
+
+    test 'delegates Enumerable methods to items' do
+      page = Page.build(PAGING_BODY)
+
+      assert_equal 1, page.size
+      assert_not page.empty?
+      assert_equal ['1'], page.map(&:id)
+    end
+
+    test 'last_page? is true when next is absent' do
+      page = Page.build(PAGING_BODY.merge('next' => nil))
+
+      assert_predicate page, :last_page?
+    end
+
+    test 'last_page? is false when next is present' do
+      page = Page.build(PAGING_BODY)
+
+      assert_not page.last_page?
+    end
+
+    test 'build tolerates a nil body' do
+      page = Page.build(nil)
+
+      assert_equal [], page.items
+      assert_nil page.total
+      assert_empty page
+      assert_predicate page, :last_page?
+    end
+
+    test 'build tolerates a body without items' do
+      page = Page.build({ 'total' => 0 })
+
+      assert_equal [], page.items
+      assert_equal 0, page.total
+      assert_empty page
+    end
+  end
+end

--- a/test/lib/spotify_api/playlist_test.rb
+++ b/test/lib/spotify_api/playlist_test.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class PlaylistTest < ActiveSupport::TestCase
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+    FakeConfig = Struct.new(:access_token, :adapter)
+    FakeSession = Struct.new(:access_token, :spotify_user_id)
+
+    setup do
+      @stubs = Faraday::Adapter::Test::Stubs.new
+      Playlist.client = build_client
+      @session = FakeSession.new('USER_TOKEN', 'spotify-uid')
+    end
+
+    teardown do
+      # 差し込んだ Client、記憶させた items_path / create のフォールバック先が
+      # テスト間で漏れないよう、必ずリセットする。
+      Playlist.reset_client!
+      Playlist.reset_items_path!
+    end
+
+    test 'find requests playlists/{id} and wraps the response body' do
+      requested_path = {}
+      @stubs.get('/v1/playlists/pl1') do |env|
+        requested_path[:value] = env.url.path
+        [200, JSON_HEADERS, { id: 'pl1', name: 'Youkai Mountain' }.to_json]
+      end
+
+      playlist = Playlist.find(@session, 'pl1')
+
+      assert_equal '/v1/playlists/pl1', requested_path[:value]
+      assert_instance_of Response, playlist
+      assert_equal 'Youkai Mountain', playlist.name
+    end
+
+    test 'requests are authorized with the session access token, not the application token' do
+      Playlist.client = build_client(with_authorization: true)
+      request_headers = {}
+      @stubs.get('/v1/playlists/pl1') do |env|
+        request_headers[:value] = env.request_headers.dup
+        [200, JSON_HEADERS, { id: 'pl1' }.to_json]
+      end
+
+      Playlist.find(@session, 'pl1')
+
+      assert_equal 'Bearer USER_TOKEN', request_headers[:value]['Authorization']
+    end
+
+    test 'items defaults to the /tracks path and forwards limit/offset' do
+      requested_path = {}
+      query = {}
+      @stubs.get('/v1/playlists/pl1/tracks') do |env|
+        requested_path[:value] = env.url.path
+        query[:value] = env.url.query
+        [200, JSON_HEADERS, { items: [{ id: 't1' }], total: 1 }.to_json]
+      end
+
+      page = Playlist.items(@session, 'pl1', limit: 50, offset: 100)
+
+      assert_equal '/v1/playlists/pl1/tracks', requested_path[:value]
+      assert_equal 'limit=50&offset=100', query[:value]
+      assert_instance_of Page, page
+      assert_equal 't1', page.items.first.id
+    end
+
+    test 'falls back to /items exactly once when /tracks responds 404, then remembers it' do
+      tracks_calls = 0
+      items_calls = 0
+
+      @stubs.get('/v1/playlists/pl1/tracks') do
+        tracks_calls += 1
+        [404, JSON_HEADERS, { error: { status: 404, message: 'not found' } }.to_json]
+      end
+      @stubs.get('/v1/playlists/pl1/items') do
+        items_calls += 1
+        [200, JSON_HEADERS, { items: [{ id: 't1' }] }.to_json]
+      end
+
+      Playlist.items(@session, 'pl1')
+      Playlist.items(@session, 'pl1')
+
+      assert_equal 1, tracks_calls
+      assert_equal 2, items_calls
+    end
+
+    # 429 でフォールバックすると、レート制限中に同じリクエストを2倍撃つことになる。
+    # NotFoundError のとき以外は絶対にフォールバックしないことの回帰防止テスト。
+    test 'does not fall back on a 429 response; the error propagates instead' do
+      tracks_calls = 0
+      items_calls = 0
+
+      @stubs.get('/v1/playlists/pl1/tracks') do
+        tracks_calls += 1
+        [429, JSON_HEADERS.merge('Retry-After' => '30'), { error: { status: 429, message: 'rate limited' } }.to_json]
+      end
+      @stubs.get('/v1/playlists/pl1/items') do
+        items_calls += 1
+        [200, JSON_HEADERS, { items: [] }.to_json]
+      end
+
+      assert_raises(RateLimitError) { Playlist.items(@session, 'pl1') }
+
+      assert_equal 1, tracks_calls
+      assert_equal 0, items_calls
+    end
+
+    test 'mine requests me/playlists and returns a Page' do
+      @stubs.get('/v1/me/playlists') { [200, JSON_HEADERS, { items: [{ id: 'p1' }], total: 1 }.to_json] }
+
+      page = Playlist.mine(@session)
+
+      assert_instance_of Page, page
+      assert_equal 'p1', page.items.first.id
+    end
+
+    test 'create posts to me/playlists with name, public and description' do
+      body = {}
+      @stubs.post('/v1/me/playlists') do |env|
+        body[:value] = JSON.parse(env.body)
+        [201, JSON_HEADERS, { id: 'new-playlist' }.to_json]
+      end
+
+      playlist = Playlist.create(@session, name: 'Youkai Mountain', public: false, description: 'arrange songs')
+
+      assert_equal({ 'name' => 'Youkai Mountain', 'public' => false, 'description' => 'arrange songs' }, body[:value])
+      assert_equal 'new-playlist', playlist.id
+    end
+
+    # POST /users/{user_id}/playlists は廃止告知済みで、後継は POST /me/playlists。
+    # me/playlists が 404 のときだけ廃止予定のパスへフォールバックし、以降はそちらを
+    # 直接使うことを確認する。
+    test 'falls back to users/{id}/playlists exactly once when me/playlists responds 404, then remembers it' do
+      me_calls = 0
+      users_calls = 0
+
+      @stubs.post('/v1/me/playlists') do
+        me_calls += 1
+        [404, JSON_HEADERS, { error: { status: 404, message: 'not found' } }.to_json]
+      end
+      @stubs.post('/v1/users/spotify-uid/playlists') do
+        users_calls += 1
+        [201, JSON_HEADERS, { id: 'new-playlist' }.to_json]
+      end
+
+      Playlist.create(@session, name: 'Youkai Mountain')
+      Playlist.create(@session, name: 'Another')
+
+      assert_equal 1, me_calls
+      assert_equal 2, users_calls
+    end
+
+    test 'add_items posts uris to the items path' do
+      body = {}
+      @stubs.post('/v1/playlists/pl1/tracks') do |env|
+        body[:value] = JSON.parse(env.body)
+        [201, JSON_HEADERS, { snapshot_id: 'snap1' }.to_json]
+      end
+
+      result = Playlist.add_items(@session, 'pl1', %w[spotify:track:1 spotify:track:2])
+
+      assert_equal({ 'uris' => %w[spotify:track:1 spotify:track:2] }, body[:value])
+      assert_equal 'snap1', result.snapshot_id
+    end
+
+    test 'remove_items sends a DELETE with a tracks body' do
+      body = {}
+      @stubs.delete('/v1/playlists/pl1/tracks') do |env|
+        body[:value] = JSON.parse(env.body)
+        [200, JSON_HEADERS, { snapshot_id: 'snap2' }.to_json]
+      end
+
+      result = Playlist.remove_items(@session, 'pl1', ['spotify:track:1'])
+
+      assert_equal({ 'tracks' => [{ 'uri' => 'spotify:track:1' }] }, body[:value])
+      assert_equal 'snap2', result.snapshot_id
+    end
+
+    test 'replace_items sends a PUT with a uris body' do
+      body = {}
+      @stubs.put('/v1/playlists/pl1/tracks') do |env|
+        body[:value] = JSON.parse(env.body)
+        [200, JSON_HEADERS, { snapshot_id: 'snap3' }.to_json]
+      end
+
+      result = Playlist.replace_items(@session, 'pl1', ['spotify:track:9'])
+
+      assert_equal({ 'uris' => ['spotify:track:9'] }, body[:value])
+      assert_equal 'snap3', result.snapshot_id
+    end
+
+    test 'all_items concatenates every page and stops at the last page' do
+      @stubs.get('/v1/playlists/pl1/tracks') do |env|
+        offset = URI.decode_www_form(env.url.query.to_s).to_h['offset'].to_i
+        page_body(offset)
+      end
+
+      items = Playlist.all_items(@session, 'pl1', limit: 2)
+
+      assert_equal %w[t1 t2 t3], items.map(&:id)
+    end
+
+    # total が信頼できない、あるいは next が終わらないレスポンスへの保険。
+    # items が空のページを受け取った時点で必ず止まることを確認する（無限ループ防止）。
+    test 'all_items stops as soon as a page returns no items' do
+      calls = 0
+      @stubs.get('/v1/playlists/pl1/tracks') do
+        calls += 1
+        [200, JSON_HEADERS,
+         { items: [], total: 100, limit: 100, offset: 0,
+           next: 'https://api.spotify.com/v1/playlists/pl1/tracks?offset=100&limit=100' }.to_json]
+      end
+
+      items = Playlist.all_items(@session, 'pl1')
+
+      assert_equal [], items
+      assert_equal 1, calls
+    end
+
+    private
+
+    def page_body(offset)
+      case offset
+      when 0
+        [200, JSON_HEADERS,
+         { items: [{ id: 't1' }, { id: 't2' }], total: 3, limit: 2, offset: 0,
+           next: 'https://api.spotify.com/v1/playlists/pl1/tracks?offset=2&limit=2' }.to_json]
+      when 2
+        [200, JSON_HEADERS, { items: [{ id: 't3' }], total: 3, limit: 2, offset: 2, next: nil }.to_json]
+      else
+        raise "unexpected offset #{offset}"
+      end
+    end
+
+    def build_client(with_authorization: false)
+      connection = Faraday.new(url: Config::API_URL) do |conn|
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
+        conn.request(:authorization, 'Bearer', -> { 'APP_TOKEN' }) if with_authorization
+        conn.adapter :test, @stubs
+      end
+
+      Client.new(FakeConfig.new('APP_TOKEN', :test), connection:)
+    end
+  end
+end

--- a/test/lib/spotify_api/response_test.rb
+++ b/test/lib/spotify_api/response_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class ResponseTest < ActiveSupport::TestCase
+    ALBUM_BODY = {
+      'id' => '4aawyAB9vmqN3uQ7FjRGTy',
+      'name' => 'Global Warming',
+      'label' => '東方同人音楽流通',
+      'external_ids' => { 'upc' => '4571364253716' },
+      'external_urls' => { 'spotify' => 'https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy' },
+      'artists' => [{ 'id' => '0TnOYISbd1XYRBk9myaseg', 'name' => 'Pitbull' }]
+    }.freeze
+
+    test 'builds an object with method access for a hash' do
+      album = Response.build(ALBUM_BODY)
+
+      assert_equal '4aawyAB9vmqN3uQ7FjRGTy', album.id
+      assert_equal 'Global Warming', album.name
+      assert_equal '東方同人音楽流通', album.label
+    end
+
+    test 'builds an array of objects for an array' do
+      albums = Response.build([ALBUM_BODY, ALBUM_BODY])
+
+      assert_equal 2, albums.size
+      assert_equal 'Global Warming', albums.first.name
+    end
+
+    test 'returns non hash values as they are' do
+      assert_nil Response.build(nil)
+      assert_equal 'string', Response.build('string')
+      assert_equal 42, Response.build(42)
+    end
+
+    test 'keeps nested values as raw hashes and arrays' do
+      album = Response.build(ALBUM_BODY)
+
+      assert_equal '4571364253716', album.external_ids['upc']
+      assert_equal 'https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy', album.external_urls['spotify']
+      assert_equal 'Pitbull', album.artists.first['name']
+    end
+
+    test 'as_json returns the raw hash' do
+      album = Response.build(ALBUM_BODY)
+
+      assert_equal ALBUM_BODY, album.as_json
+      assert_same ALBUM_BODY, album.as_json
+    end
+
+    test 'returns nil for an undefined key without raising' do
+      album = Response.build(ALBUM_BODY)
+
+      assert_nil album.unknown_attribute
+      assert_not_respond_to album, :unknown_attribute
+    end
+
+    test 'raises NoMethodError for a call with arguments' do
+      album = Response.build(ALBUM_BODY)
+
+      assert_raises(NoMethodError) { album.unknown_attribute('argument') }
+    end
+
+    test 'supports key access with both strings and symbols' do
+      album = Response.build(ALBUM_BODY)
+
+      assert_equal 'Global Warming', album['name']
+      assert_equal 'Global Warming', album[:name]
+      assert_nil album[:unknown_attribute]
+    end
+
+    test 'key? tells whether the key exists' do
+      album = Response.build(ALBUM_BODY)
+
+      assert album.key?('label')
+      assert album.key?(:label)
+      assert_not album.key?(:unknown_attribute)
+    end
+
+    test 'to_h returns the raw hash' do
+      album = Response.build(ALBUM_BODY)
+
+      assert_equal ALBUM_BODY, album.to_h
+      assert_respond_to album, :name
+    end
+  end
+end

--- a/test/lib/spotify_api/track_test.rb
+++ b/test/lib/spotify_api/track_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class TrackTest < ActiveSupport::TestCase
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+    FakeConfig = Struct.new(:access_token, :adapter)
+
+    setup do
+      @stubs = Faraday::Adapter::Test::Stubs.new
+      Track.client = build_client
+    end
+
+    teardown do
+      # 差し込んだ Client がテスト間で漏れないよう、必ずリセットする。
+      Track.reset_client!
+    end
+
+    test 'find does not send a market parameter by default' do
+      query = capture_query('/v1/tracks/123', { id: '123' })
+
+      Track.find('123')
+
+      assert_nil query[:value]
+    end
+
+    test 'find sends market only when explicitly given' do
+      query = capture_query('/v1/tracks/123', { id: '123' })
+
+      Track.find('123', market: 'JP')
+
+      assert_equal 'market=JP', query[:value]
+    end
+
+    test 'find wraps the response body' do
+      @stubs.get('/v1/tracks/123') { [200, JSON_HEADERS, { id: '123', name: 'track' }.to_json] }
+
+      track = Track.find('123')
+
+      assert_instance_of Response, track
+      assert_equal 'track', track.name
+    end
+
+    test 'find_many fetches each id individually instead of using the bulk endpoint' do
+      @stubs.get('/v1/tracks/1') { [200, JSON_HEADERS, { id: '1' }.to_json] }
+      @stubs.get('/v1/tracks/2') { [200, JSON_HEADERS, { id: '2' }.to_json] }
+
+      tracks = Track.find_many(%w[1 2])
+
+      assert_equal %w[1 2], tracks.map(&:id)
+    end
+
+    test 'find_many skips ids that respond with 404' do
+      @stubs.get('/v1/tracks/1') { [200, JSON_HEADERS, { id: '1' }.to_json] }
+      @stubs.get('/v1/tracks/2') { [404, JSON_HEADERS, { error: { status: 404, message: 'not found' } }.to_json] }
+
+      tracks = Track.find_many(%w[1 2])
+
+      assert_equal ['1'], tracks.map(&:id)
+    end
+
+    test 'find_many propagates errors other than 404, such as rate limiting' do
+      @stubs.get('/v1/tracks/1') { [429, JSON_HEADERS, { error: { status: 429, message: 'rate limited' } }.to_json] }
+
+      assert_raises(RateLimitError) { Track.find_many(%w[1]) }
+    end
+
+    private
+
+    def build_client
+      connection = Faraday.new(url: Config::API_URL) do |conn|
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
+        conn.adapter :test, @stubs
+      end
+
+      Client.new(FakeConfig.new('TOKEN', :test), connection:)
+    end
+
+    def capture_query(path, body)
+      query = {}
+      @stubs.get(path) do |env|
+        query[:value] = env.url.query
+        [200, JSON_HEADERS, body.to_json]
+      end
+      query
+    end
+  end
+end

--- a/test/lib/spotify_api/user_session_test.rb
+++ b/test/lib/spotify_api/user_session_test.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SpotifyApi
+  class UserSessionTest < ActiveSupport::TestCase
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+
+    # RedisPool をスタブするための最小限の Redis 互換オブジェクト。
+    # 実 Redis には一切依存しない。
+    class FakeRedis
+      def initialize(store = {})
+        @store = store
+      end
+
+      def get(key)
+        @store[key]
+      end
+
+      def set(key, value)
+        @store[key] = value
+      end
+    end
+
+    setup do
+      @stubs = Faraday::Adapter::Test::Stubs.new
+      @config = Config.new
+      @config.client_id = 'CLIENT_ID'
+      @config.client_secret = 'CLIENT_SECRET'
+      @config.token_connection = Faraday.new do |conn|
+        conn.response :json, content_type: /\bjson$/
+        conn.adapter :test, @stubs
+      end
+    end
+
+    test 'access_token returns the existing token while it is still within the refresh margin' do
+      calls = stub_refresh('NEW')
+      session = build_session(token: 'OLD', expires_in: 3600)
+
+      assert_equal 'OLD', session.access_token
+
+      travel_to 3600.seconds.from_now - UserSession::REFRESH_MARGIN - 1.minute do
+        assert_equal 'OLD', session.access_token
+      end
+
+      assert_equal 0, calls.value
+    end
+
+    test 'access_token refreshes once the refresh margin is reached' do
+      calls = stub_refresh('NEW')
+      session = build_session(token: 'OLD', expires_in: 3600)
+
+      travel_to 3600.seconds.from_now - UserSession::REFRESH_MARGIN + 1.minute do
+        assert_equal 'NEW', session.access_token
+      end
+
+      assert_equal 1, calls.value
+    end
+
+    test 'refresh! reflects the refreshed token and expiry' do
+      stub_refresh('NEW', expires_in: 1800)
+      session = build_session(token: 'OLD', expires_in: 3600)
+
+      session.refresh!
+
+      assert_equal 'NEW', session.access_token
+      assert_in_delta (Time.current + 1800).to_i, session.expires_at.to_i, 1
+    end
+
+    test 'keeps the existing refresh_token when the refresh response does not include one' do
+      stub_refresh('NEW', include_refresh_token: false)
+      session = build_session(token: 'OLD', expires_in: -10, refresh_token: 'ORIGINAL_REFRESH')
+
+      session.access_token
+
+      assert_equal 'ORIGINAL_REFRESH', session.refresh_token
+    end
+
+    test 'rotates the refresh_token when the refresh response includes a new one' do
+      stub_refresh('NEW', include_refresh_token: true)
+      session = build_session(token: 'OLD', expires_in: -10, refresh_token: 'ORIGINAL_REFRESH')
+
+      session.access_token
+
+      assert_equal 'ROTATED_REFRESH', session.refresh_token
+    end
+
+    test 'writes the refreshed auth_hash back to Redis when user_id is known' do
+      stub_refresh('NEW', expires_in: 1800)
+      fake_redis = FakeRedis.new
+      session = build_session(token: 'OLD', expires_in: -10, user_id: 'user-1')
+
+      stub_redis_pool(fake_redis) do
+        session.access_token
+      end
+
+      saved = JSON.parse(fake_redis.get('user-1'))
+
+      assert_equal 'NEW', saved['credentials']['token']
+    end
+
+    test 'does not write back to Redis when user_id is unknown' do
+      stub_refresh('NEW', expires_in: 1800)
+      session = build_session(token: 'OLD', expires_in: -10, user_id: nil)
+
+      stub_redis_pool(raises: 'RedisPool.with must not be called without a user_id') do
+        assert_equal 'NEW', session.access_token
+      end
+    end
+
+    test 'does not raise when writing back to Redis fails; the refreshed token is still returned' do
+      stub_refresh('NEW', expires_in: 1800)
+      session = build_session(token: 'OLD', expires_in: -10, user_id: 'user-1')
+
+      stub_redis_pool(raises: IOError.new('boom')) do
+        assert_equal 'NEW', session.access_token
+      end
+    end
+
+    test 'raises AuthenticationError when the token is expired and there is no refresh_token' do
+      session = build_session(token: 'OLD', expires_in: -10, refresh_token: nil)
+
+      assert_raises(AuthenticationError) { session.access_token }
+    end
+
+    test 'raises AuthenticationError when the refresh endpoint responds with a non-200 status' do
+      @stubs.post('/api/token') { [400, JSON_HEADERS, { error: 'invalid_grant' }.to_json] }
+      session = build_session(token: 'OLD', expires_in: -10)
+
+      error = assert_raises(AuthenticationError) { session.access_token }
+
+      assert_equal 400, error.status
+      assert_not_nil error.response
+    end
+
+    test 'find loads the auth_hash from Redis' do
+      auth_json = build_auth_hash(token: 'STORED', expires_in: 3600).to_json
+      fake_redis = FakeRedis.new('user-1' => auth_json)
+
+      session = stub_redis_pool(fake_redis) { UserSession.find('user-1', config: @config) }
+
+      assert_equal 'STORED', session.access_token
+      assert_equal 'spotify-uid', session.spotify_user_id
+    end
+
+    # rspotify の RSpotify::User は該当ユーザーの認証情報が見つからないと
+    # 「最初に登録されたユーザーのトークン」にフォールバックし、別人のアカウントを
+    # 操作してしまう事故につながる（rspotify/user.rb:66）。SpotifyApi::UserSession は
+    # この挙動を絶対に引き継がず、見つからなければ nil を返すだけであることを確認する。
+    test 'find returns nil instead of falling back to another user\'s credentials' do
+      fake_redis = FakeRedis.new('user-1' => build_auth_hash(token: 'STORED', expires_in: 3600).to_json)
+
+      session = stub_redis_pool(fake_redis) { UserSession.find('user-2', config: @config) }
+
+      assert_nil session
+    end
+
+    test 'access_token refreshes only once when called from multiple threads' do
+      calls = stub_refresh('NEW', delay: 0.05)
+      session = build_session(token: 'OLD', expires_in: -10)
+
+      tokens = Array.new(5) { Thread.new { session.access_token } }.map(&:value)
+
+      assert_equal ['NEW'] * 5, tokens
+      assert_equal 1, calls.value
+    end
+
+    private
+
+    # RedisPool.with を一時的に差し替える。minitest 6 は Object#stub（旧 minitest/mock）を
+    # 同梱しなくなったため、ここでは特異メソッドの差し替え・復元を自前で行う。
+    # fake_redis を渡すとそれを yield し、raises を渡すと RedisPool.with 呼び出し自体を
+    # 例外にする（「呼ばれないこと」「呼び出しが失敗しても処理が継続すること」の検証用）。
+    def stub_redis_pool(fake_redis = nil, raises: nil)
+      original = RedisPool.singleton_class.instance_method(:with)
+      RedisPool.define_singleton_method(:with) do |&blk|
+        raise raises if raises
+
+        blk.call(fake_redis)
+      end
+
+      yield
+    ensure
+      RedisPool.define_singleton_method(:with, original)
+    end
+
+    def build_session(token:, expires_in:, refresh_token: 'REFRESH', user_id: nil)
+      UserSession.new(build_auth_hash(token:, expires_in:, refresh_token:), user_id:, config: @config)
+    end
+
+    def build_auth_hash(token:, expires_in:, refresh_token: 'REFRESH')
+      {
+        'provider' => 'spotify',
+        'uid' => 'spotify-uid',
+        'info' => { 'id' => 'spotify-uid', 'display_name' => 'Reimu' },
+        'credentials' => {
+          'token' => token,
+          'refresh_token' => refresh_token,
+          'expires_at' => Time.current.to_i + expires_in,
+          'expires' => true
+        }
+      }
+    end
+
+    # トークンエンドポイントをスタブし、呼び出し回数を数えるカウンタを返す。
+    def stub_refresh(token, expires_in: 3600, include_refresh_token: true, delay: nil)
+      calls = Concurrent::AtomicFixnum.new(0)
+
+      @stubs.post('/api/token') do
+        calls.increment
+        sleep delay if delay
+        body = { access_token: token, expires_in: expires_in }
+        body[:refresh_token] = 'ROTATED_REFRESH' if include_refresh_token
+        [200, JSON_HEADERS, body.to_json]
+      end
+
+      calls
+    end
+  end
+end


### PR DESCRIPTION
Closes #560
親 Issue: #564

## 概要

rspotify / spotify-client からの移行に向けて、Spotify Web API の HTTP・認証・レスポンス整形を担う `lib/spotify_api/` を新設しました。

**この PR では既存コードから一切呼び出していません。振る舞いの変更はゼロです。**（`app/` 配下の変更は 0 件）

`lib/apple_music/` の3層パターン（Config / Client / Response + リソースクラス）を踏襲しています。

## 追加したファイル

| ファイル | 役割 |
|---|---|
| `lib/spotify_api.rb` | autoload + `config` / `configure` / `native_client_enabled?` |
| `lib/spotify_api/errors.rb` | 例外階層 |
| `lib/spotify_api/config.rb` | ENV 読み込み + Client Credentials トークン（Mutex + TTL） |
| `lib/spotify_api/client.rb` | Faraday 実行 + ステータス→例外変換 |
| `lib/spotify_api/response.rb` | 生 Hash をメソッドアクセス可能に包む |
| `lib/spotify_api/page.rb` | ページングオブジェクトのラッパー |
| `lib/spotify_api/album.rb` | `find` / `find_many` / `tracks` / `search` |
| `lib/spotify_api/track.rb` | `find` / `find_many` |
| `lib/spotify_api/audio_features.rb` | `find` / `find_many` |
| `lib/spotify_api/playlist.rb` | `find` / `items` / `all_items` / `mine` / `create` / `add_items` / `remove_items` / `replace_items` |
| `lib/spotify_api/user_session.rb` | Authorization Code トークン（期限事前チェック・リフレッシュ・Redis 書き戻し） |
| `config/initializers/spotify_api.rb` | `SpotifyApi.configure` |

## 設計上のポイント

### 429 を Faraday のリトライ対象から外した

`ExternalApi::Connection` に `spotify` プロファイルを追加し、`retry_statuses` から **429 を意図的に除外**しました。

Spotify は Development Mode のクォータ超過時に `Retry-After: 64063`（約17.8時間）のような極端な値を返すことがあり、faraday-retry はその値ぶんスレッドをブロックして待機してしまいます。429 のハンドリングは既存の `SpotifyRetry` / `SpotifyRateLimit` に委ねます。

これに伴い、リトライ設定のマージ順を `**SHARED_RETRY_OPTIONS, **profile[:retry]` に変更し、プロファイル側から共通設定を上書きできるようにしました。他プロファイルは `retry_statuses` を指定していないため影響はありません。

### トークン取得専用プロファイル `spotify_accounts` を追加

`spotify` プロファイルは `methods: %i[get]` のため、`accounts.spotify.com` へのトークン取得（POST）が 5xx で失敗してもリトライされません。長時間バッチの途中で一過性の 502 を踏むと処理全体が落ちるため、POST をリトライする専用プロファイルを分けました。

API 本体側で POST をリトライしないのは、プレイリストへの項目追加など非冪等な操作を含むためです。

### 暗黙の追加リクエストを実装しない

`RSpotify::Base#method_missing` は未取得の属性にアクセスされると裏で API を叩き直します。これが現在のクォータ枯渇の主因（#558）のため、`SpotifyApi::Response` では**未定義キーは nil を返すだけ**にしています。

### `Album.find` は既定で market を送らない

`market` を指定すると Spotify は `available_markets` を返さず `is_playable` に置換します。`SpotifyAlbum#jp_available?` が `available_markets` を参照しているため、market を付けると**日本で配信中のアルバムが「配信終了」と誤判定されて削除される**危険があります（#559）。回帰防止テストを入れています。

### バルク取得エンドポイントを使わない

`GET /albums?ids=` / `GET /tracks?ids=` は 2026年2月に廃止が告知されているため、`find_many` は逐次取得で実装しました。404 はスキップして warn ログを出し、429 などはそのまま伝播させます（レート制限を握りつぶさない）。

### 他ユーザーのトークンへフォールバックしない

`RSpotify::User` は該当ユーザーの認証情報が見つからないと「最初に登録されたユーザーのトークン」にフォールバックします（`rspotify/user.rb:66`）。マルチユーザー環境で**別人のアカウントにプレイリストを書き込む**事故につながるため、この挙動は引き継いでいません。

### トークンの取り扱いを改善

- 期限を**事前チェック**してリフレッシュ（rspotify は 401 が返ってからエラーメッセージの文字列マッチでリフレッシュしており、毎回1往復を無駄にしている）
- 更新後のトークンを **Redis に書き戻す**（rspotify はクラス変数上でしか更新せず永続化されていない）
- リフレッシュ応答に `refresh_token` が含まれない場合は既存値を維持（nil で上書きすると以後リフレッシュ不能になるため）
- Redis 書き戻しの失敗では処理を落とさず warn ログにとどめる
- 起動時にネットワーク I/O を走らせない遅延取得方式（`config/initializers/rspotify.rb` の `after_initialize` 方式とは異なる方針）

### 移行用フィーチャーフラグ

`SPOTIFY_NATIVE_CLIENT`（既定 `false`）を追加しました。この PR の時点では誰も参照していませんが、後続 Issue で rspotify 経路と SpotifyApi 経路の切替点を1か所に集約し、移行完了後（#563）にフラグと旧経路の分岐をまとめて削除できるようにするための土台です。

## 未確認事項

Spotify のクォータが枯渇しており（2026-07-26 時点で `GET /v1/albums/{id}` が 429 `QUOTA_EXCEEDED`, `Retry-After: 14889`）、以下は実 API で未検証です。

- `/playlists/{id}/tracks` → `/items` のリネームがどちらで有効か
  - 既定は動作実績のある `tracks`。ENV `SPOTIFY_PLAYLIST_ITEMS_PATH` で切替可能にした上で、**404 のときだけ**もう一方のパスへ1回フォールバックする実装にしています（429 や 5xx ではフォールバックしません）
- `POST /users/{id}/playlists` → `POST /me/playlists` も同様のフォールバックを実装
- `audio-features` の生死。deprecated のため 403/404 では警告ログを出して空を返し、バッチ全体が落ちないようにしています（429 は伝播）

実 API 疎通確認はクォータ回復後に行います。

## 確認結果

```
$ make rubocop
248 files inspected, no offenses detected

$ make minitest
361 runs, 1623 assertions, 0 failures, 0 errors, 0 skips

$ devbox run -- bin/rails zeitwerk:check
All is good!
```

`app/` 配下の変更は 0 件です。
